### PR TITLE
Feature/Script for automated package publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,129 @@
+## Temporary node files
+*.log
+network-logs/**
+.idea
+/node_modules
+.pid
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### GPG template
+secring.*
+
+### MinIO server logs
+network-logs/minio-server/data/**
+
+scripts

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+{
+    gh --version
+} || {
+    echo
+    echo
+    echo "Github-CLI is not installed. Please refer to: https://cli.github.com/"
+    exit 1
+}
+cd ../
+{
+	user=$(npm whoami 2> /dev/null) && echo "You are logged in NPM as $user"
+} || {
+	npm login
+}
+gh auth login
+
+echo
+echo
+echo "How would you like to bump the package version (the format is: major.minor.patch):"
+
+options=(
+	"Bump patch version"
+	"Bump minor version"
+	"Bump major version"
+	"None. The version is already bumped"
+	)
+
+versionType=none
+
+echo
+echo
+
+select opt in "${options[@]}"
+do
+    case $opt in
+        "Bump patch version")
+            versionType=patch
+            break;
+            ;;
+        "Bump minor version")
+            versionType=minor
+            break;
+            ;;
+        "Bump major version")
+            versionType=major
+            break;
+            ;;
+        "None. The version is already bumped")
+			echo "Skipping version bumping"
+            break
+            ;;
+        *) echo "invalid option $REPLY";;
+    esac
+done
+
+if [ "$versionType" != none ]
+then
+    echo
+    echo
+    echo "Checkout to default branch..."
+    defaultBranch=`basename $(git symbolic-ref --short refs/remotes/origin/HEAD)`
+    git checkout $defaultBranch
+    git pull
+
+    echo "Bumping version - $versionType"
+    npm version $versionType -s
+    version=`node --eval="process.stdout.write(require('./package.json').version)"`
+
+    echo
+    echo
+    echo "Checkout new branch: v$version"
+    git branch v$version
+    git checkout v$version
+    git push --set-upstream origin HEAD:v$version
+    git push --tags
+    gh pr create --fill
+    echo
+    echo
+    echo "Please merge the created PR before continuing the script execution"
+    while true; do
+        read -p "Is the PR merged? (y/n)?" choice
+        case "$choice" in
+          y|Y ) echo "PR is merged"; break;;
+          n|N ) echo "canceled" && exit 0;;
+          * ) echo;;
+        esac
+    done
+    git checkout $defaultBranch
+    gh release create v$version
+else
+    gh release create
+fi
+
+echo
+echo
+echo "Publishing to NPM..."
+npm publish


### PR DESCRIPTION
**Description**:
Adds a bash script for automating the publishing process. It performs the following actions:
- Bumps the package version. User is propted to specify whether a patch, minor or major version needs to be bumped.
- Pushes the updated `package.json` to a new branch and opens a PR
- Once the PR CICD passes and it is merged the script will continue to the next step.
- Creates a Release
- Publishes the updated package to NPM

Usage:
```
cd scripts
bash publish.sh
```

Requirements:
- [Github CLI](https://cli.github.com/)
- nodejs
- Whoever is going to execute the script needs to have the required access to push new branches to the repository, open PRs and create Releases.

**Related issue(s)**:

Fixes #

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
