### PR TITLE
Newest docker images(0.26.2) not working on Apple M1

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=main-network-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.26.2
-HAVEGED_IMAGE_TAG=0.26.2
+NETWORK_NODE_IMAGE_TAG=0.26.3
+HAVEGED_IMAGE_TAG=0.26.3
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m

--- a/README.md
+++ b/README.md
@@ -115,8 +115,25 @@ Mirror Node Url - http://127.0.0.1:5551
 
 ## Installation
 
+#### Official NPM Release
+The command below can be used to install the official release from the NPM repository. This version may not reflect
+the most recent changes to the `main` branch of this repository. 
+
+This version uses a baked in version of the Docker Compose definitions and will not reflect any local changes made to 
+the repository. 
+
 ```bash
 npm install --save-dev @hashgraph/hedera-local
+```
+
+#### Local Module
+The command below can be used to install the `hedera-local` module as a symlink against your locally checked out copy of 
+this repository.
+
+This is the recommended method for testing against the latest changes or a point in time version from a branch/tag. 
+
+```bash
+npm install -g
 ```
 
 ## Using hedera-local

--- a/cli.js
+++ b/cli.js
@@ -74,9 +74,10 @@ Available commands:
     console.log('Stopping the docker containers...');
     shell.exec('docker-compose down -v 2>/dev/null');
     console.log('Cleaning the volumes and temp files...');
+    shell.exec('rm -rf network-logs/* >/dev/null 2>&1')
     // shell.exec(`git clean -xfd 2>/dev/null`);
-    shell.exec('sed -i \'s/^.*PLATFORM_JAVA_OPTS/PLATFORM_JAVA_OPTS/\' .env');
-    shell.exec('sed -i \'s/PLATFORM_JAVA_OPTS/#PLATFORM_JAVA_OPTS/\' .env');
+    // shell.exec('sed -i \'s/^.*PLATFORM_JAVA_OPTS/PLATFORM_JAVA_OPTS/\' .env');
+    // shell.exec('sed -i \'s/PLATFORM_JAVA_OPTS/#PLATFORM_JAVA_OPTS/\' .env');
   }
 
   process.exit();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@hashgraph/hethers": "^1.0.3",
-    "@hashgraph/sdk": "2.7.0-beta.4",
+    "@hashgraph/sdk": "2.15.0",
     "js-yaml": "^4.1.0",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5"

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,4 +1,9 @@
 const shell = require('shelljs');
 
-shell.exec('sed -i \'s/PLATFORM_JAVA_OPTS/#PLATFORM_JAVA_OPTS/\' .env');
-shell.exec('docker-compose build');
+/*
+Neither of the below items are currently needed. The `PLATFORM_JAVA_OPTS` should not be commented out and the current
+docker compose definitions do not support inline builds.
+*/
+
+// shell.exec('sed -i \'s/PLATFORM_JAVA_OPTS/#PLATFORM_JAVA_OPTS/\' .env');
+// shell.exec('docker-compose build');


### PR DESCRIPTION
**Description**:

Resolves the issue reported in #91 and also fixes some issues in `postinstall.js` and the `stop` command.

**Related issue(s)**:

Fixes #91 
