### PR TITLE
Update mirror node version to 0.58 to match mainnet mirror node version

### DIFF
--- a/.env
+++ b/.env
@@ -27,7 +27,7 @@ PYTHON_VERSION=python3.9
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.57.2
+MIRROR_IMAGE_TAG=0.58.0
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=postgres:13.5-alpine


### PR DESCRIPTION
Signed-off-by: Nathan Klick <nathan@swirldslabs.com>

**Description**:
Update mirror node version to `0.58.0` to match mainnet mirror node version.

**Related issue(s)**:

Fixes #98
