### PR TITLE
Feature/00112 update node mirror versions

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=main-network-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.26.3
-HAVEGED_IMAGE_TAG=0.26.3
+NETWORK_NODE_IMAGE_TAG=0.27.4
+HAVEGED_IMAGE_TAG=0.27.4
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m
@@ -27,7 +27,7 @@ PYTHON_VERSION=python3.9
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.58.0
+MIRROR_IMAGE_TAG=0.59.1
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=postgres:13.5-alpine

--- a/.github/workflows/update-config-files.yaml
+++ b/.github/workflows/update-config-files.yaml
@@ -17,7 +17,7 @@ env:
   REMOTE_REPO_OWNER: hashgraph
   REMOTE_REPO_NAME: hedera-services
   REMOTE_CONFIG_PATH: master/hedera-node/configuration
-  REMOTE_CONFIG_PROFILE: previewnet
+  REMOTE_CONFIG_PROFILE: testnet
   REPO_CONFIG_PATH: compose-network/network-node/data/config
   PR_REVIEWERS: "beeradb,Neeharika-Sompalli,nathanklick,tannerjfco,steven-sheehy"
   PR_ASSIGNEES: "swirlds-automation"

--- a/compose-network/network-node/data/config/api-permission.properties
+++ b/compose-network/network-node/data/config/api-permission.properties
@@ -10,7 +10,6 @@ getTxRecordByTxID=0-*
 getTransactionReceipts=0-*
 approveAllowances=0-*
 deleteAllowances=0-*
-prng=0-*
 # File
 createFile=0-*
 updateFile=0-*
@@ -60,10 +59,12 @@ tokenDissociateFromAccount=0-*
 tokenFeeScheduleUpdate=0-*
 tokenPause=0-*
 tokenUnpause=0-*
-# Network 
+# Network
 getVersionInfo=0-*
 networkGetExecutionTime=2-50
 systemDelete=2-59
 systemUndelete=2-60
 freeze=2-58
 getAccountDetails=2-50
+# Util
+prng=0-*

--- a/compose-network/network-node/data/config/bootstrap.properties
+++ b/compose-network/network-node/data/config/bootstrap.properties
@@ -1,3 +1,3 @@
-ledger.id=0x02
+ledger.id=0x01
 netty.mode=DEV
 contracts.chainId=296

--- a/compose-network/network-node/data/config/bootstrap.properties
+++ b/compose-network/network-node/data/config/bootstrap.properties
@@ -1,6 +1,3 @@
 ledger.id=0x02
 netty.mode=DEV
 contracts.chainId=297
-bootstrap.genesisPublicKey=c249a323c878f5b5e2daccda6d731e6fdc32f870228d1cd4fae559d947dbc36c
-hedera.recordStream.recordFileVersion=6
-hedera.recordStream.signatureFileVersion=6

--- a/compose-network/network-node/data/config/bootstrap.properties
+++ b/compose-network/network-node/data/config/bootstrap.properties
@@ -1,3 +1,3 @@
 ledger.id=0x02
 netty.mode=DEV
-contracts.chainId=297
+contracts.chainId=296


### PR DESCRIPTION
**Description**:

Updates node software and mirror node versions. Updates configuration files to use `testnet` capable configuration instead of `previewnet` based config. 

**Related issue(s)**:

Fixes #112 

