### PR TITLE
Update configuration file to use previewnet's configuration

### DIFF
--- a/.github/workflows/update-config-files.yaml
+++ b/.github/workflows/update-config-files.yaml
@@ -16,8 +16,8 @@ env:
   REMOTE_RAW_URL_BASE: https://raw.githubusercontent.com
   REMOTE_REPO_OWNER: hashgraph
   REMOTE_REPO_NAME: hedera-services
-  REMOTE_CONFIG_PATH: master/hedera-node/configuration
-  REMOTE_CONFIG_PROFILE: testnet
+  REMOTE_CONFIG_PATH: develop/hedera-node/configuration
+  REMOTE_CONFIG_PROFILE: previewnet
   REPO_CONFIG_PATH: compose-network/network-node/data/config
   PR_REVIEWERS: "beeradb,Neeharika-Sompalli,nathanklick,tannerjfco,steven-sheehy"
   PR_ASSIGNEES: "swirlds-automation"


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:
Update GitHub workflow to use the configuration for previewnet when setting up local node.  

**Related issue(s)**:
https://github.com/hashgraph/hedera-services/pull/4061

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
