### PR TITLE
Performance updates

### DIFF
--- a/src/helpers/connectionCheck.js
+++ b/src/helpers/connectionCheck.js
@@ -15,12 +15,12 @@ module.exports = class ConnectionCheck {
         })
         .on("error", (err) => {
           logger.log(
-            `Waiting for the containers at ${host}:${port}, retrying in 20 seconds...`
+            `Waiting for the containers at ${host}:${port}, retrying in 0.1 seconds...`
           );
           logger.log(err);
         });
 
-      await new Promise((r) => setTimeout(r, 20000));
+      await new Promise((r) => setTimeout(r, 100));
     }
   }
 

--- a/src/utils/nodeController.js
+++ b/src/utils/nodeController.js
@@ -18,6 +18,7 @@ module.exports = class NodeController {
     console.log("Stopping the network...");
     shell.cd(__dirname);
     console.log("Stopping the docker containers...");
+    shell.exec(`docker-compose kill 2>${nullOutput}`);
     shell.exec(`docker-compose down -v 2>${nullOutput}`);
     console.log("Cleaning the volumes and temp files...");
     shell.exec(`rm -rf network-logs/* >${nullOutput} 2>&1`);


### PR DESCRIPTION
**Description**:
This PR modifies check connection timeout and the stop action in order to improve performance on startup and shutdown
* Change timeout
* Change docker command

**Related issue(s)**:
Addresses #162 


**Notes for reviewer**:
Startup on a 2020 Intel MacBook Pro before took on average 1:58 m, after on average 1:06 m
Stop on the same machine before took on average 31 s, after on average 7 s

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
