### PR TITLE
feat: add a docker compose overlay to disable minio/mirror.py for EVM testing

### DIFF
--- a/docker-compose.evm.yml
+++ b/docker-compose.evm.yml
@@ -1,0 +1,18 @@
+version: "2.4"
+services:
+  record-streams-uploader:
+    restart: "no"
+    entrypoint: ["echo", "This container is intentionally disabled by the EVM profile."]
+  account-balances-uploader:
+    restart: "no"
+    entrypoint: [ "echo", "This container is intentionally disabled by the EVM profile." ]
+  record-sidecar-uploader:
+    restart: "no"
+    entrypoint: [ "echo", "This container is intentionally disabled by the EVM profile." ]
+  minio:
+    restart: "no"
+    entrypoint: [ "echo", "This container is intentionally disabled by the EVM profile." ]
+  importer:
+    volumes:
+      - "${NETWORK_NODE_LOGS_ROOT_PATH}/accountBalances:/streams/balances"
+      - "${NETWORK_NODE_LOGS_ROOT_PATH}/recordStreams:/streams/records"

--- a/docker-compose.evm.yml
+++ b/docker-compose.evm.yml
@@ -18,5 +18,5 @@ services:
     command: []
   importer:
     volumes:
-      - "${NETWORK_NODE_LOGS_ROOT_PATH}/accountBalances:/streams/balances"
-      - "${NETWORK_NODE_LOGS_ROOT_PATH}/recordStreams:/streams/records"
+      - "${NETWORK_NODE_LOGS_ROOT_PATH}/accountBalances:/streams/accountBalances"
+      - "${NETWORK_NODE_LOGS_ROOT_PATH}/recordStreams:/streams/recordstreams"

--- a/docker-compose.evm.yml
+++ b/docker-compose.evm.yml
@@ -17,6 +17,7 @@ services:
     entrypoint: [ "echo", "This container is intentionally disabled by the EVM profile." ]
     command: []
   importer:
+    user: "root"
     volumes:
-      - "${NETWORK_NODE_LOGS_ROOT_PATH}/accountBalances:/streams/accountBalances"
-      - "${NETWORK_NODE_LOGS_ROOT_PATH}/recordStreams:/streams/recordstreams"
+      - "${NETWORK_NODE_LOGS_ROOT_PATH}/accountBalances/balance0.0.3:/node/streams/accountBalances/balance0.0.3"
+      - "${NETWORK_NODE_LOGS_ROOT_PATH}/recordStreams/record0.0.3:/node/streams/recordstreams/record0.0.3"

--- a/docker-compose.evm.yml
+++ b/docker-compose.evm.yml
@@ -17,7 +17,6 @@ services:
     entrypoint: [ "echo", "This container is intentionally disabled by the EVM profile." ]
     command: []
   importer:
-    user: "root"
     volumes:
       - "${NETWORK_NODE_LOGS_ROOT_PATH}/accountBalances/balance0.0.3:/node/streams/accountBalances/balance0.0.3"
       - "${NETWORK_NODE_LOGS_ROOT_PATH}/recordStreams/record0.0.3:/node/streams/recordstreams/record0.0.3"

--- a/docker-compose.evm.yml
+++ b/docker-compose.evm.yml
@@ -3,15 +3,19 @@ services:
   record-streams-uploader:
     restart: "no"
     entrypoint: ["echo", "This container is intentionally disabled by the EVM profile."]
+    command: []
   account-balances-uploader:
     restart: "no"
     entrypoint: [ "echo", "This container is intentionally disabled by the EVM profile." ]
+    command: []
   record-sidecar-uploader:
     restart: "no"
     entrypoint: [ "echo", "This container is intentionally disabled by the EVM profile." ]
+    command: []
   minio:
     restart: "no"
     entrypoint: [ "echo", "This container is intentionally disabled by the EVM profile." ]
+    command: []
   importer:
     volumes:
       - "${NETWORK_NODE_LOGS_ROOT_PATH}/accountBalances:/streams/balances"


### PR DESCRIPTION
## Description

This PR adds an EVM layer for the docker compose definitions. The mirror node code configuration changes below will need to be incorporated into a template via a separate issue/PR. 

To utilize the EVM overlay, docker compose should be launched with these additional arguments: 

`-f docker-compose.yml -f docker-compose.evm.yml`

**Example:**
```
docker-compose -f docker-compose.yml -f docker-compose.evm.yml up -d
```

### Mirror Node Configuration Changes

```yaml
hedera:
    importer:
      ..............
      downloader:
        ........
        sources:
          - type: LOCAL
      dataPath: file:///node/
      ............
```

#### Diff
```
diff --git forkSrcPrefix/compose-network/mirror-node/application.yml forkDstPrefix/compose-network/mirror-node/application.yml
index 66152ae92758b1450c82e2ec31dded7791861b4c..06b0f4069255136ec6962fc65cedb4481e4c6170 100644
--- forkSrcPrefix/compose-network/mirror-node/application.yml
+++ forkDstPrefix/compose-network/mirror-node/application.yml
@@ -18,6 +18,9 @@ hedera:
         bucketName: hedera-streams
         endpointOverride: http://minio:9000
         timeout: 180s
+        sources:
+          - type: LOCAL
+      dataPath: file:///node/
       initialAddressBook: "/usr/etc/hedera-mirror-importer/local-dev-1-node.addressbook.f102.json.bin"
       network: OTHER
     monitor:
```

### Related Issues 

- Closes #270 