### PR TITLE
Set Turbo mode to be default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Available commands:
             --n or --network to override the default configuration. Defaults to mainnet.
             --l or --limits to enable/disable the JSON-RPC relay rate limits. Defaults to true.
             --dev to enable/disable developer mode.
-            --turbo to enable/disable turbo mode. Faster local-node
             --full to enable/disable full mode. Production local-node.
             --balance to set starting hbar balance of the created accounts.
     stop - Stops the local hedera network and delete all the existing data.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Available commands:
             --n or --network to override the default configuration. Defaults to mainnet.
             --l or --limits to enable/disable the JSON-RPC relay rate limits. Defaults to true.
             --dev to enable/disable developer mode.
-            --turbo to enable/disable turbo mode.
+            --turbo to enable/disable turbo mode. Faster local-node
+            --full to enable/disable full mode. Production local-node.
             --balance to set starting hbar balance of the created accounts.
     stop - Stops the local hedera network and delete all the existing data.
     restart - Restart the local hedera network.

--- a/cli.js
+++ b/cli.js
@@ -22,12 +22,11 @@ yargs(hideBin(process.argv))
       CliOptions.addNetworkOption(yargs);
       CliOptions.addRateLimitOption(yargs);
       CliOptions.addDevModeOption(yargs);
-      CliOptions.addTurboModeOption(yargs);
       CliOptions.addFullModeOption(yargs);
       CliOptions.addBalanceOption(yargs);
     },
     async (argv) => {
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.turbo, argv.full);
+      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full);
       await main(argv.accounts, argv.balance, argv.detached, argv.host);
     }
   )
@@ -48,13 +47,12 @@ yargs(hideBin(process.argv))
       CliOptions.addNetworkOption(yargs);
       CliOptions.addRateLimitOption(yargs);
       CliOptions.addDevModeOption(yargs);
-      CliOptions.addTurboModeOption(yargs);
       CliOptions.addFullModeOption(yargs);
       CliOptions.addBalanceOption(yargs);
     },
     async (argv) => {
       await NodeController.stopLocalNode();
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.turbo, argv.full);
+      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full);
       await main(argv.accounts, argv.balance, argv.detached, argv.host);
     }
   )

--- a/cli.js
+++ b/cli.js
@@ -23,10 +23,11 @@ yargs(hideBin(process.argv))
       CliOptions.addRateLimitOption(yargs);
       CliOptions.addDevModeOption(yargs);
       CliOptions.addTurboModeOption(yargs);
+      CliOptions.addFullModeOption(yargs);
       CliOptions.addBalanceOption(yargs);
     },
     async (argv) => {
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.turbo);
+      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.turbo, argv.full);
       await main(argv.accounts, argv.balance, argv.detached, argv.host);
     }
   )
@@ -48,11 +49,12 @@ yargs(hideBin(process.argv))
       CliOptions.addRateLimitOption(yargs);
       CliOptions.addDevModeOption(yargs);
       CliOptions.addTurboModeOption(yargs);
+      CliOptions.addFullModeOption(yargs);
       CliOptions.addBalanceOption(yargs);
     },
     async (argv) => {
       await NodeController.stopLocalNode();
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.turbo);
+      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.turbo, argv.full);
       await main(argv.accounts, argv.balance, argv.detached, argv.host);
     }
   )

--- a/src/utils/cliOptions.js
+++ b/src/utils/cliOptions.js
@@ -62,15 +62,6 @@ module.exports = class CliOptions {
     })
   }
 
-  static addTurboModeOption(yargs) {
-    yargs.option("turbo", {
-      type: 'boolean',
-      describe: "Enable or disable turbo mode. Faster local-node.",
-      demandOption: false,
-      default: true,
-    })
-  }
-
   static addFullModeOption(yargs) {
     yargs.option("full", {
       type: 'boolean',

--- a/src/utils/cliOptions.js
+++ b/src/utils/cliOptions.js
@@ -65,9 +65,18 @@ module.exports = class CliOptions {
   static addTurboModeOption(yargs) {
     yargs.option("turbo", {
       type: 'boolean',
-      describe: "Enable or disable turbo mode",
+      describe: "Enable or disable turbo mode. Faster local-node.",
       demandOption: false,
       default: true,
+    })
+  }
+
+  static addFullModeOption(yargs) {
+    yargs.option("full", {
+      type: 'boolean',
+      describe: "Enable or disable full mode. Production local-node.",
+      demandOption: false,
+      default: false,
     })
   }
 

--- a/src/utils/cliOptions.js
+++ b/src/utils/cliOptions.js
@@ -67,7 +67,7 @@ module.exports = class CliOptions {
       type: 'boolean',
       describe: "Enable or disable turbo mode",
       demandOption: false,
-      default: false,
+      default: true,
     })
   }
 

--- a/src/utils/nodeController.js
+++ b/src/utils/nodeController.js
@@ -26,7 +26,7 @@ module.exports = class NodeController {
     shell.cd(rootPath);
   }
 
-  static async startLocalNode(network, limits, devMode, turboMode) {
+  static async startLocalNode(network, limits, devMode, turboMode, fullMode) {
     await this.applyConfig(network, limits, devMode, turboMode);
 
     const dockerStatus = await DockerCheck.checkDocker();
@@ -40,7 +40,7 @@ module.exports = class NodeController {
     shell.cd(__dirname);
     shell.cd("../../");
     const dockerComposeUpCmd = () => {
-      return (turboMode)
+      return (turboMode && !fullMode)
           ? shell.exec(`docker-compose -f docker-compose.yml -f docker-compose.evm.yml up -d 2>${nullOutput}`)
           : shell.exec(`docker-compose up -d 2>${nullOutput}`);
     };

--- a/src/utils/nodeController.js
+++ b/src/utils/nodeController.js
@@ -26,8 +26,8 @@ module.exports = class NodeController {
     shell.cd(rootPath);
   }
 
-  static async startLocalNode(network, limits, devMode, turboMode, fullMode) {
-    await this.applyConfig(network, limits, devMode, turboMode);
+  static async startLocalNode(network, limits, devMode, fullMode) {
+    await this.applyConfig(network, limits, devMode, fullMode);
 
     const dockerStatus = await DockerCheck.checkDocker();
     if (!dockerStatus) {
@@ -40,9 +40,9 @@ module.exports = class NodeController {
     shell.cd(__dirname);
     shell.cd("../../");
     const dockerComposeUpCmd = () => {
-      return (turboMode && !fullMode)
-          ? shell.exec(`docker-compose -f docker-compose.yml -f docker-compose.evm.yml up -d 2>${nullOutput}`)
-          : shell.exec(`docker-compose up -d 2>${nullOutput}`);
+      return (fullMode)
+          ? shell.exec(`docker-compose up -d 2>${nullOutput}`)
+          : shell.exec(`docker-compose -f docker-compose.yml -f docker-compose.evm.yml up -d 2>${nullOutput}`);
     };
     const output = dockerComposeUpCmd();
     if (output.code == 1) {
@@ -61,7 +61,7 @@ module.exports = class NodeController {
     shell.cd(rootPath);
   }
 
-  static async applyConfig(network, limits, devMode, turboMode) {
+  static async applyConfig(network, limits, devMode, fullMode) {
     shell.cd(rootPath);
     shell.echo(`Applying ${network} config settings...`);
     const baseFolder = path.resolve(__dirname, "../../");
@@ -104,7 +104,7 @@ module.exports = class NodeController {
       shell.echo(`Successfully applied ${network} config settings`);
     }
 
-    if (turboMode) {
+    if (!fullMode) {
       const yaml = require("js-yaml");
       const fs = require("fs");
       const application = yaml.load(fs.readFileSync(`${baseFolder}/compose-network/mirror-node/application.yml`));


### PR DESCRIPTION
**Description**:
This PR changes configuration to enable starting of turbo mode to default.
Also adds full mode for starting a production-like local-node. Can be started with `--full`

**Related issue(s)**:

Fixes #303 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
