### PR TITLE
Add support for user Compose definitions

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -26,9 +26,11 @@ yargs(hideBin(process.argv))
       CliOptions.addBalanceOption(yargs);
       CliOptions.addAsyncOption(yargs);
       CliOptions.addMultiNodeOption(yargs);
+      CliOptions.addUserComposeOption(yargs);
+      CliOptions.addUserComposeDirOption(yargs);
     },
     async (argv) => {
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode, argv.host);
+      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode, argv.host, argv.usercompose, argv.composedir);
       await main(argv.accounts, argv.async, argv.balance, argv.detached, argv.host);
     }
   )
@@ -53,10 +55,12 @@ yargs(hideBin(process.argv))
       CliOptions.addBalanceOption(yargs);
       CliOptions.addAsyncOption(yargs);
       CliOptions.addMultiNodeOption(yargs);
+      CliOptions.addUserComposeOption(yargs);
+      CliOptions.addUserComposeDirOption(yargs);
     },
     async (argv) => {
       await NodeController.stopLocalNode();
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode, argv.host);
+      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode, argv.host, argv.usercompose, argv.composedir);
       await main(argv.accounts, argv.async, argv.balance, argv.detached, argv.host);
     }
   )

--- a/cli.js
+++ b/cli.js
@@ -16,21 +16,10 @@ yargs(hideBin(process.argv))
     "start [accounts]",
     "Starts the local hedera network.",
     (yargs) => {
-      CliOptions.addAccountsOption(yargs);
-      CliOptions.addDetachedOption(yargs);
-      CliOptions.addHostOption(yargs);
-      CliOptions.addNetworkOption(yargs);
-      CliOptions.addRateLimitOption(yargs);
-      CliOptions.addDevModeOption(yargs);
-      CliOptions.addFullModeOption(yargs);
-      CliOptions.addBalanceOption(yargs);
-      CliOptions.addAsyncOption(yargs);
-      CliOptions.addMultiNodeOption(yargs);
-      CliOptions.addUserComposeOption(yargs);
-      CliOptions.addUserComposeDirOption(yargs);
+      loadStartCliOptions(yargs);
     },
     async (argv) => {
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode, argv.host, argv.usercompose, argv.composedir);
+      await NodeController.startLocalNode(argv);
       await main(argv.accounts, argv.async, argv.balance, argv.detached, argv.host);
     }
   )
@@ -45,22 +34,11 @@ yargs(hideBin(process.argv))
     "restart [accounts]",
     "Restart the local hedera network.",
     (yargs) => {
-      CliOptions.addAccountsOption(yargs);
-      CliOptions.addDetachedOption(yargs);
-      CliOptions.addHostOption(yargs);
-      CliOptions.addNetworkOption(yargs);
-      CliOptions.addRateLimitOption(yargs);
-      CliOptions.addDevModeOption(yargs);
-      CliOptions.addFullModeOption(yargs);
-      CliOptions.addBalanceOption(yargs);
-      CliOptions.addAsyncOption(yargs);
-      CliOptions.addMultiNodeOption(yargs);
-      CliOptions.addUserComposeOption(yargs);
-      CliOptions.addUserComposeDirOption(yargs);
+      loadStartCliOptions(yargs);
     },
     async (argv) => {
       await NodeController.stopLocalNode();
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode, argv.host, argv.usercompose, argv.composedir);
+      await NodeController.startLocalNode(argv);
       await main(argv.accounts, argv.async, argv.balance, argv.detached, argv.host);
     }
   )
@@ -208,4 +186,23 @@ async function startDetached(accounts, async, balance, host) {
   await HederaUtils.prepareNode(async, console, balance, accounts, true, host);
   console.log("\nLocal node has been successfully started in detached mode.");
   process.exit();
+}
+
+/**
+ * Loads the node starting options
+ * @param {yargs} yargs
+ */
+function loadStartCliOptions(yargs) {
+  CliOptions.addAccountsOption(yargs);
+  CliOptions.addDetachedOption(yargs);
+  CliOptions.addHostOption(yargs);
+  CliOptions.addNetworkOption(yargs);
+  CliOptions.addRateLimitOption(yargs);
+  CliOptions.addDevModeOption(yargs);
+  CliOptions.addFullModeOption(yargs);
+  CliOptions.addBalanceOption(yargs);
+  CliOptions.addAsyncOption(yargs);
+  CliOptions.addMultiNodeOption(yargs);
+  CliOptions.addUserComposeOption(yargs);
+  CliOptions.addUserComposeDirOption(yargs);
 }

--- a/src/utils/cliOptions.js
+++ b/src/utils/cliOptions.js
@@ -98,4 +98,20 @@ module.exports = class CliOptions {
       default: false,
     })
   }
+  static addUserComposeOption(yargs) {
+    yargs.option('usercompose', {
+      type: 'boolean',
+      describe: "Enable or disable user Compose configuration files",
+      demandOption: false,
+      default: true
+    })
+  }
+  static addUserComposeDirOption(yargs) {
+    yargs.option('composedir', {
+      type: 'string',
+      describe: 'Path to a directory with user Compose configuration files',
+      demandOption: false,
+      default: './overrides',
+    })
+  }
 }

--- a/src/utils/cliOptions.js
+++ b/src/utils/cliOptions.js
@@ -111,7 +111,7 @@ module.exports = class CliOptions {
       type: 'string',
       describe: 'Path to a directory with user Compose configuration files',
       demandOption: false,
-      default: './overrides',
+      default: './overrides/',
     })
   }
 }

--- a/src/utils/nodeController.js
+++ b/src/utils/nodeController.js
@@ -167,8 +167,14 @@ module.exports = class NodeController {
   }
 
   static getUserComposeFiles(dirPath = './overrides/') {
+    dirPath = path.normalize(dirPath);
+    if (!dirPath.endsWith(path.sep)) {
+      dirPath += path.sep;
+    }
     if (fs.existsSync(dirPath)) {
-      const files = fs.readdirSync(dirPath).sort().map(file => dirPath.concat(file));
+      const files = fs.readdirSync(dirPath)
+        .filter(file => path.extname(file).toLowerCase() === '.yml')
+        .sort().map(file => dirPath.concat(file));
       return files;
     } else {
       return [];

--- a/src/utils/nodeController.js
+++ b/src/utils/nodeController.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const yargs = require("yargs");
 const fs = require("fs");
 const os = require("os");
 const shell = require("shelljs");
@@ -27,7 +28,12 @@ module.exports = class NodeController {
     shell.cd(rootPath);
   }
 
-  static async startLocalNode(network, limits, devMode, fullMode, multiNode, host, userCompose, composeDir) {
+  /**
+   * Checks the nessecery arguments and start the local node
+   * @param {yargs.ArgumentsCamelCase<{}>} argv
+   */
+  static async startLocalNode(argv) {
+    const { network, limits, devMode, fullMode, multiNode, host, userCompose, composeDir } = argv;
     await this.applyConfig(network, limits, devMode, fullMode, multiNode, host);
 
     const dockerStatus = await DockerCheck.checkDocker();

--- a/src/utils/nodeController.js
+++ b/src/utils/nodeController.js
@@ -27,7 +27,7 @@ module.exports = class NodeController {
     shell.cd(rootPath);
   }
 
-  static async startLocalNode(network, limits, devMode, fullMode, multiNode, host) {
+  static async startLocalNode(network, limits, devMode, fullMode, multiNode, host, userCompose, composeDir) {
     await this.applyConfig(network, limits, devMode, fullMode, multiNode, host);
 
     const dockerStatus = await DockerCheck.checkDocker();
@@ -50,6 +50,9 @@ module.exports = class NodeController {
         if (!fullMode) {
           composeFiles.push('docker-compose.multinode.evm.yml');
         }
+      }
+      if (userCompose) {
+        composeFiles.push(...this.getUserComposeFiles(composeDir));
       }
       return shell.exec(`docker compose -f ${composeFiles.join(' -f ')} up -d 2>${nullOutput}`);
     };
@@ -161,5 +164,14 @@ module.exports = class NodeController {
 
     lines.splice(target, 1, `${key}=${value}`);
     fs.writeFileSync(envPath, lines.join(os.EOL));
+  }
+
+  static getUserComposeFiles(dirPath = './overrides/') {
+    if (fs.existsSync(dirPath)) {
+      const files = fs.readdirSync(dirPath).sort().map(file => dirPath.concat(file));
+      return files;
+    } else {
+      return [];
+    }
   }
 };


### PR DESCRIPTION
**Description**:
This PR adds two new cli options
`--usercompose` with a default value of `true`, which enables/disables support for user Compose definitions
`--composedir` with a default value of "./overrides" which defines the directory containing the desired user Compose definitions
When the option is enabled it loads all of the files in the specified directory in alphabetical order as additional Compose definitions allowing the user to modify the default local node setup.

* Add cli options


**Related issue(s)**:

Fixes #330 

**Notes for reviewer**:
Here's an example of a custom Compose definition, that disables prometheus and grafana it can be put in a file with ".yml" extension in a `overrides` directory at the root of the project to test

```yaml
services:
  grafana:
    profiles:
      - disabled
  prometheus:
    profiles:
      - disabled
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
