### PR TITLE
Make host option affect explorer mirror node url

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ yargs(hideBin(process.argv))
       CliOptions.addMultiNodeOption(yargs);
     },
     async (argv) => {
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode);
+      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode, argv.host);
       await main(argv.accounts, argv.async, argv.balance, argv.detached, argv.host);
     }
   )
@@ -56,7 +56,7 @@ yargs(hideBin(process.argv))
     },
     async (argv) => {
       await NodeController.stopLocalNode();
-      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode);
+      await NodeController.startLocalNode(argv.network, argv.limits, argv.dev, argv.full, argv.multinode, argv.host);
       await main(argv.accounts, argv.async, argv.balance, argv.detached, argv.host);
     }
   )

--- a/src/utils/nodeController.js
+++ b/src/utils/nodeController.js
@@ -27,8 +27,8 @@ module.exports = class NodeController {
     shell.cd(rootPath);
   }
 
-  static async startLocalNode(network, limits, devMode, fullMode, multiNode) {
-    await this.applyConfig(network, limits, devMode, fullMode, multiNode);
+  static async startLocalNode(network, limits, devMode, fullMode, multiNode, host) {
+    await this.applyConfig(network, limits, devMode, fullMode, multiNode, host);
 
     const dockerStatus = await DockerCheck.checkDocker();
     if (!dockerStatus) {
@@ -70,7 +70,7 @@ module.exports = class NodeController {
     shell.cd(rootPath);
   }
 
-  static async applyConfig(network, limits, devMode, fullMode, multiNode) {
+  static async applyConfig(network, limits, devMode, fullMode, multiNode, host) {
     shell.cd(rootPath);
     shell.echo(`Applying ${network} config settings...`);
     const baseFolder = path.resolve(__dirname, "../../");
@@ -105,6 +105,11 @@ module.exports = class NodeController {
       relayRateLimitDisabled
     );
     NodeController.setEnvValue(`${baseFolder}/.env`, "RELAY_DEV_MODE", devMode);
+    NodeController.setEnvValue(
+      `${baseFolder}/.env`,
+      "VUE_APP_LOCAL_MIRROR_NODE_URL",
+      `http://${host}:5551/`
+    )
     if (multiNode) {
       NodeController.setEnvValue(`${baseFolder}/.env`, "RELAY_HEDERA_NETWORK", '{"network-node:50211":"0.0.3","network-node-1:50211":"0.0.4","network-node-2:50211":"0.0.5","network-node-3:50211":"0.0.6"}');
     }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Thus PR modifies `NodeController.js` and `cli.js` in order to `host` option can affect the `VUE_APP_LOCAL_MIRROR_NODE_URL` env variable.
So when starting hedera-local-node with option `--host`, hedera-explorer can fetch data from the actual host that the operator sets in arguments.

**Related issue(s)**:

Fixes #333 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Explorer fetch from the host set with `--host` option with this PR.
<img width="467" alt="image" src="https://github.com/hashgraph/hedera-local-node/assets/16640149/42ac679a-f104-4f07-8ce7-b6359a2e15c6">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
