### PR TITLE
Fix cli argument parsing

### DIFF
--- a/src/utils/nodeController.js
+++ b/src/utils/nodeController.js
@@ -33,7 +33,7 @@ module.exports = class NodeController {
    * @param {yargs.ArgumentsCamelCase<{}>} argv
    */
   static async startLocalNode(argv) {
-    const { network, limits, devMode, fullMode, multiNode, host, userCompose, composeDir } = argv;
+    const { network, limits, dev: devMode, full: fullMode, multinode: multiNode, host, usercompose: userCompose, composedir: composeDir } = argv;
     await this.applyConfig(network, limits, devMode, fullMode, multiNode, host);
 
     const dockerStatus = await DockerCheck.checkDocker();


### PR DESCRIPTION
**Description**:
This PR fixes a bug which prevents the proper parsing of cli arguments for the `start` and `restart` commands.



**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
