### PR TITLE
Fix Docker Check error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -171,7 +171,7 @@ async function start(accounts, async, balance, host, eventLogger, accountLogger)
   eventLogger.log("Starting the network...");
 
   eventLogger.log("Preparing Node...");
-  await HederaUtils.prepareNode(async, accountLogger, async, balance, accounts, true, host);
+  await HederaUtils.prepareNode(async, accountLogger, balance, accounts, true, host);
 }
 
 /**

--- a/src/helpers/dockerCheck.js
+++ b/src/helpers/dockerCheck.js
@@ -67,7 +67,11 @@ module.exports = class DockerCheck {
         if (err) {
           reject(err);
         } else {
-          resolve(containers[0].Image.split(":")[1]);
+          try {
+            resolve(containers[0].Image.split(":")[1]);
+          } catch (e) {
+            resolve(constants.UNKNOWN_VERSION);
+          }
         }
       });
     });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -19,5 +19,6 @@ module.exports = {
     CONSENSUS_NODE_LABEL: "network-node",
     MIRROR_NODE_LABEL: "mirror-node-rest",
     RELAY_LABEL: "json-rpc-relay",
-    IS_WINDOWS: process.platform === "win32"
+    IS_WINDOWS: process.platform === "win32",
+    UNKNOWN_VERSION: "Unknown"
 }


### PR DESCRIPTION
**Description**:
In some cases we check for the images version, before they are started, therefore this results in an error. This PR fixes this by setting the version to Unknown and afterwards updating it to the actual when the containers are started.
Also fixes issue when starting normal mode (not detached)

**Related issue(s)**:

Fixes #347 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
