### PR TITLE
Bump Local Node Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-local",
-      "version": "2.12.1",
+      "version": "2.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/hethers": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "homepage": "https://github.com/hashgraph/hedera-local-node",
   "repository": "github.com:hashgraph/hedera-local-node",


### PR DESCRIPTION
**Description**:
This PR bumps hedera-local-node version to 2.13

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
