### PR TITLE
Argument for verbose print of output console when starting up the local node

### DIFF
--- a/src/utils/cliOptions.js
+++ b/src/utils/cliOptions.js
@@ -127,4 +127,13 @@ module.exports = class CliOptions {
       default: false
     });
   }
+
+  static addVerboseOption (yargs) {
+    yargs.option('verbose', {
+      type: 'boolean',
+      describe: 'Enable or disable verbose output',
+      demandOption: false,
+      default: false
+    });
+  }
 };

--- a/src/utils/hederaUtils.js
+++ b/src/utils/hederaUtils.js
@@ -24,7 +24,7 @@ module.exports = class HederaUtils {
     await shell.exec(
       `docker exec mirror-node-db psql mirror_node -U mirror_node -c "INSERT INTO public.file_data(file_data, consensus_timestamp, entity_id, transaction_type) VALUES (decode('${fees}', 'hex'), ${
         timestamp + '000000'
-      }, ${feesFileId}, 17);" >> ${NodeController.getNullOutput()}`
+      }, ${feesFileId}, 17);" >> ${NodeController.getConsoleOutput()}`
     );
 
     const exchangeRatesFileId = 112;
@@ -37,7 +37,7 @@ module.exports = class HederaUtils {
     await shell.exec(
       `docker exec mirror-node-db psql mirror_node -U mirror_node -c "INSERT INTO public.file_data(file_data, consensus_timestamp, entity_id, transaction_type) VALUES (decode('${exchangeRates}', 'hex'), ${
         timestamp + '000001'
-      }, ${exchangeRatesFileId}, 17);" >> ${NodeController.getNullOutput()}`
+      }, ${exchangeRatesFileId}, 17);" >> ${NodeController.getConsoleOutput()}`
     );
   }
 
@@ -125,7 +125,9 @@ module.exports = class HederaUtils {
     const recordExt = `.${process.env.STREAM_EXTENSION}`;
     for (const file of files) {
       const recordFileName = file.replace(recordExt, '');
-      const fileTimestamp = new Date(recordFileName.replace(/_/g, ':')).getTime();
+      const fileTimestamp = new Date(
+        recordFileName.replace(/_/g, ':')
+      ).getTime();
       if (fileTimestamp >= jsTimestamp) {
         if (file.endsWith(recordExt)) {
           logger.log(`Parsing record file [${file}]\n`);


### PR DESCRIPTION
**Description**:
- Added an option parameter `--verbose`.
- If that parameter is present, the script will output all the subcommands to `dev/stdout` instead of `dev/null` so is easier to troubleshoot.

**Related issue(s)**:

Fixes #412 

**Notes for reviewer**:

**Logs when happy path and no verbose option is added:** (stays the same)

```
Admins-Laptop:hedera-local-node user$ node cli.js start --network local  -d
Checking docker compose version...
Applying local config settings...
Successfully applied local config settings
Starting hedera local node in single-node mode...
Detecting the network...
Starting the network...
Preparing Node...
Importing fees...
Waiting for topic creation...
Generating accounts in synchronous mode...
|-----------------------------------------------------------------------------------------|
|-----------------------------| Accounts list ( ECDSA  keys) |----------------------------|
|-----------------------------------------------------------------------------------------|
|    id    |                            private key                            |  balance |
|-----------------------------------------------------------------------------------------|
| 0.0.1002 - 0x53d5e65d91ff6857e41acca2cf8f5d69155ee53a9422601930e7d9d447fc6009 - 10000 ℏ |
| 0.0.1003 - 0x3cda030eefcf906cb9ddc3adac3ebde8a972dc2b1a5f1a17a6c6687192e0da57 - 10000 ℏ |
| 0.0.1004 - 0x8c839e39cc113a9898cf22598c19f3023075e9433c0f977a9b776725e131273e - 10000 ℏ |
| 0.0.1005 - 0x013206c4bef4b44d29e322b11aa4bc5cb43215a9a8b67117ac6f92f2b53ded8c - 10000 ℏ |
| 0.0.1006 - 0x308aeb1c7875e97444e22273958db61c781e55d89562e4f81735e6297d9ff6e0 - 10000 ℏ |
| 0.0.1007 - 0x398e070ebf76533ad3bae00b0332e7e1caace3e96dcded46b0d0d99e43d0470d - 10000 ℏ |
| 0.0.1008 - 0xe21e6af1544a580c7bd5d10815401acba542fb0d1ac1067a60c7b1acd94f6516 - 10000 ℏ |
| 0.0.1009 - 0x6ec82f12b8f8ae9455a04e83d8c93e84aede34fe50361911e2ebea9754f7af32 - 10000 ℏ |
| 0.0.1010 - 0x82e06efcaabd8ae2918010a9b36aaac5c369e62ef325021131d15aa3935620ec - 10000 ℏ |
| 0.0.1011 - 0xe0fb0e9b84dac9fe2af78357235ff6743926207ee6f1baf61c2d9ddf15879985 - 10000 ℏ |
|-----------------------------------------------------------------------------------------|

|--------------------------------------------------------------------------------------------------------------------------------------|
|------------------------------------------------| Accounts list (Alias ECDSA keys) |--------------------------------------------------|
|--------------------------------------------------------------------------------------------------------------------------------------|
|    id    |               public address               |                             private key                            | balance |
|--------------------------------------------------------------------------------------------------------------------------------------|
| 0.0.1012 - 0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69 - 0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524 - 10000 ℏ |
| 0.0.1013 - 0x05FbA803Be258049A27B820088bab1cAD2058871 - 0x2e1d968b041d84dd120a5860cee60cd83f9374ef527ca86996317ada3d0d03e7 - 10000 ℏ |
| 0.0.1014 - 0x927E41Ff8307835A1C081e0d7fD250625F2D4D0E - 0x45a5a7108a18dd5013cf2d5857a28144beadc9c70b3bdbd914e38df4e804b8d8 - 10000 ℏ |
| 0.0.1015 - 0xc37f417fA09933335240FCA72DD257BFBdE9C275 - 0x6e9d61a325be3f6675cf8b7676c70e4a004d2308e3e182370a41f5653d52c6bd - 10000 ℏ |
| 0.0.1016 - 0xD927017F5a6a7A92458b81468Dc71FCE6115B325 - 0x0b58b1bd44469ac9f813b5aeaf6213ddaea26720f0b2f133d08b6f234130a64f - 10000 ℏ |
| 0.0.1017 - 0x5C41A21F14cFe9808cBEc1d91b55Ba75ed327Eb6 - 0x95eac372e0f0df3b43740fa780e62458b2d2cc32d6a440877f1cc2a9ad0c35cc - 10000 ℏ |
| 0.0.1018 - 0xcdaD5844f865F379beA057fb435AEfeF38361B68 - 0x6c6e6727b40c8d4b616ab0d26af357af09337299f09c66704146e14236972106 - 10000 ℏ |
| 0.0.1019 - 0x6e5D3858f53FC66727188690946631bDE0466B1A - 0x5072e7aa1b03f531b4731a32a021f6a5d20d5ddc4e55acbb71ae202fc6f3a26d - 10000 ℏ |
| 0.0.1020 - 0x29cbb51A44fd332c14180b4D471FBBc6654b1657 - 0x60fe891f13824a2c1da20fb6a14e28fa353421191069ba6b6d09dd6c29b90eff - 10000 ℏ |
| 0.0.1021 - 0x17b2B8c63Fa35402088640e426c6709A254c7fFb - 0xeae4e00ece872dd14fb6dc7a04f390563c7d69d16326f2a703ec8e0934060cc7 - 10000 ℏ |
|--------------------------------------------------------------------------------------------------------------------------------------|

|-----------------------------------------------------------------------------------------|
|-----------------------------| Accounts list (ED25519 keys) |----------------------------|
|-----------------------------------------------------------------------------------------|
|    id    |                            private key                            |  balance |
|-----------------------------------------------------------------------------------------|
| 0.0.1022 - 0x0494b4d3bfb8e3b5fe69fc9a73ec524b9f978ac2a5431e3e61fe7c9680f503f7 - 10000 ℏ |
| 0.0.1023 - 0x2c9882364494803891e71100c2bdd4998245a57dda3a85959a5398ee2bf788b9 - 10000 ℏ |
| 0.0.1024 - 0x99514cc0eeddd0012713c3df4a587d60f537daf184466a9c06c0b8e08029fbe8 - 10000 ℏ |
| 0.0.1025 - 0xb77412b46eb9f8776d41f2d06be30d2aa04c823e9aa43ccbf2bb91ece89ec80f - 10000 ℏ |
| 0.0.1026 - 0x8585fd6f22098031ec3f76caf217f42aebfd7b612155eaa40fec4d7f194ad771 - 10000 ℏ |
| 0.0.1027 - 0x15b850365653c228e576154cfd8030deefb109bde17abb73c8ed0bd7db452648 - 10000 ℏ |
| 0.0.1028 - 0xa40cebd69b0ea92e6d66534f3ababd84ce9e4d46b77eea171921bf64a213e6fe - 10000 ℏ |
| 0.0.1029 - 0xdcd73eda61d7094967fb8167aeb8591ce9aead8cad46a2fa8f14d5ecf045bf36 - 10000 ℏ |
| 0.0.1030 - 0xef83602d57c0202af61435da72aa265ec791f0314ef81ca68a75d5893fe00581 - 10000 ℏ |
| 0.0.1031 - 0x442816e78a45774ac8f2f715a03fe1defde2bf1a028dfcc44ace83a761506dee - 10000 ℏ |
|-----------------------------------------------------------------------------------------|

Local node has been successfully started in detached mode.
Admins-Laptop:hedera-local-node user$ 
```

**Logs when there is an issue and verbose is passed:**
```
Admins-Laptop:hedera-local-node user$ node cli.js start --network local  -d --verbose
Checking docker compose version...
Applying local config settings...
Successfully applied local config settings
Starting hedera local node in single-node mode...
 Container mirror-node-db  Running
 Container hedera-explorer  Running
 Container grafana  Running
 Container relay-cache  Running
 Container prometheus  Running
 Container envoy-proxy  Running
 Container haveged  Starting
 Container minio  Starting
 Container haveged  Started
Error response from daemon: Ports are not available: exposing port TCP 0.0.0.0:9000 -> 0.0.0.0:0: listen tcp 0.0.0.0:9000: bind: address already in use
haveged
network-node
record-streams-uploader
account-balances-uploader
record-sidecar-uploader
minio
mirror-node-db
mirror-node-grpc
mirror-node-importer
mirror-node-rest
hedera-explorer
mirror-node-web3
mirror-node-monitor
json-rpc-relay
json-rpc-relay-ws
envoy-proxy
prometheus
grafana
relay-cache
haveged
network-node
record-streams-uploader
account-balances-uploader
record-sidecar-uploader
minio
mirror-node-db
mirror-node-grpc
mirror-node-importer
mirror-node-rest
hedera-explorer
mirror-node-web3
mirror-node-monitor
json-rpc-relay
json-rpc-relay-ws
envoy-proxy
prometheus
grafana
relay-cache
Stopping the network...
Stopping the docker containers...
no container to kill Volume mirror-node-postgres  Removing
 Volume minio-data  Removing
 Volume prometheus-data  Removing
 Volume grafana-data  Removing
 Network cloud-storage  Removing
 Network mirror-node  Removing
 Network hedera-local-node_default  Removing
 Network network-node-bridge  Removing
 Volume minio-data  Removed
 Volume grafana-data  Removed
 Volume prometheus-data  Removed
 Volume mirror-node-postgres  Removed
 Network hedera-local-node_default  Removed
 Network cloud-storage  Removed
 Network mirror-node  Removed
 Network network-node-bridge  Removed
Cleaning the volumes and temp files...
 Network mirror-node  Creating
 Network mirror-node  Created
 Network hedera-local-node_default  Creating
 Network hedera-local-node_default  Created
 Network cloud-storage  Creating
 Network cloud-storage  Created
 Network network-node-bridge  Creating
 Network network-node-bridge  Created
 Volume "mirror-node-postgres"  Creating
 Volume "mirror-node-postgres"  Created
 Volume "grafana-data"  Creating
 Volume "grafana-data"  Created
 Volume "minio-data"  Creating
 Volume "minio-data"  Created
 Volume "prometheus-data"  Creating
 Volume "prometheus-data"  Created
 Container prometheus  Creating
 Container grafana  Creating
 Container hedera-explorer  Creating
 Container minio  Creating
 Container envoy-proxy  Creating
 Container haveged  Creating
 Container relay-cache  Creating
 Container mirror-node-db  Creating
 Container grafana  Created
 Container hedera-explorer  Created
 Container relay-cache  Created
 Container haveged  Created
 Container mirror-node-db  Created
 Container minio  Created
 Container record-streams-uploader  Creating
 Container envoy-proxy  Created
 Container record-sidecar-uploader  Creating
 Container mirror-node-importer  Creating
 Container account-balances-uploader  Creating
 Container prometheus  Created
 Container account-balances-uploader  Created
 Container record-sidecar-uploader  Created
 Container record-streams-uploader  Created
 Container network-node  Creating
 Container mirror-node-importer  Created
 Container mirror-node-web3  Creating
 Container mirror-node-rest  Creating
 Container network-node  Created
 Container mirror-node-grpc  Creating
 Container mirror-node-rest  Created
 Container json-rpc-relay  Creating
 Container json-rpc-relay-ws  Creating
 Container mirror-node-web3  Created
 Container mirror-node-grpc  Created
 Container mirror-node-monitor  Creating
 Container json-rpc-relay-ws  Created
 Container json-rpc-relay  Created
 Container mirror-node-monitor  Created
 Container haveged  Starting
 Container relay-cache  Starting
 Container grafana  Starting
 Container hedera-explorer  Starting
 Container prometheus  Starting
 Container mirror-node-db  Starting
 Container envoy-proxy  Starting
 Container minio  Starting
 Container haveged  Started
 Container relay-cache  Started
 Container hedera-explorer  Started
 Container prometheus  Started
 Container mirror-node-db  Started
 Container envoy-proxy  Started
 Container grafana  Started
Error response from daemon: Ports are not available: exposing port TCP 0.0.0.0:9000 -> 0.0.0.0:0: listen tcp 0.0.0.0:9000: bind: address already in use
Detecting the network...
Waiting for the containers at 127.0.0.1:5600, retrying in 0.1 seconds...
Error: connect ECONNREFUSED 127.0.0.1:5600
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1495:16) {
  errno: -61,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 5600
}
```


**Logs when everything works and verbose is passed:**
```
Admins-Laptop:hedera-local-node user$ node cli.js start --network local  -d --verbose
Checking docker compose version...
Applying local config settings...
Successfully applied local config settings
Starting hedera local node in single-node mode...
 Container relay-cache  Running
 Container envoy-proxy  Running
 Container mirror-node-db  Running
 Container minio  Created
 Container hedera-explorer  Recreate
 Container prometheus  Running
 Container haveged  Recreate
 Container grafana  Running
 Container record-streams-uploader  Created
 Container mirror-node-importer  Recreate
 Container record-sidecar-uploader  Created
 Container account-balances-uploader  Created
 Container haveged  Recreated
 Container network-node  Recreate
 Container hedera-explorer  Recreated
 Container mirror-node-importer  Recreated
 Container mirror-node-web3  Recreate
 Container mirror-node-rest  Recreate
 Container network-node  Recreated
 Container mirror-node-grpc  Recreate
 Container mirror-node-web3  Recreated
 Container mirror-node-grpc  Recreated
 Container mirror-node-rest  Recreated
 Container json-rpc-relay-ws  Creating
 Container mirror-node-monitor  Recreate
 Container json-rpc-relay  Recreate
 Container json-rpc-relay-ws  Created
 Container json-rpc-relay  Recreated
 Container mirror-node-monitor  Recreated
 Container haveged  Starting
 Container minio  Starting
 Container hedera-explorer  Starting
 Container haveged  Started
 Container minio  Started
 Container record-streams-uploader  Starting
 Container account-balances-uploader  Starting
 Container mirror-node-importer  Starting
 Container record-sidecar-uploader  Starting
 Container hedera-explorer  Started
 Container record-sidecar-uploader  Started
 Container record-streams-uploader  Started
 Container network-node  Starting
 Container account-balances-uploader  Started
 Container mirror-node-importer  Started
 Container mirror-node-web3  Starting
 Container mirror-node-rest  Starting
 Container network-node  Started
 Container mirror-node-grpc  Starting
 Container mirror-node-web3  Started
 Container mirror-node-rest  Started
 Container network-node  Waiting
 Container network-node  Waiting
 Container mirror-node-grpc  Started
 Container network-node  Waiting
 Container network-node  Healthy
 Container json-rpc-relay-ws  Starting
 Container network-node  Healthy
 Container json-rpc-relay  Starting
 Container network-node  Healthy
 Container mirror-node-monitor  Starting
 Container json-rpc-relay-ws  Started
 Container json-rpc-relay  Started
 Container mirror-node-monitor  Started
Detecting the network...
Starting the network...
Preparing Node...
Importing fees...
INSERT 0 1
INSERT 0 1
Waiting for topic creation...
Generating accounts in synchronous mode...
|-----------------------------------------------------------------------------------------|
|-----------------------------| Accounts list ( ECDSA  keys) |----------------------------|
|-----------------------------------------------------------------------------------------|
|    id    |                            private key                            |  balance |
|-----------------------------------------------------------------------------------------|
| 0.0.1002 - 0xfc470ca197825bb3efa1c70a0fe16819e734f0b37ad352341e47263fcca7a3c8 - 10000 ℏ |
| 0.0.1003 - 0xc347f3cae88d1d7f91c34246fa5d1c14e0a9147baf01cf701daa2aef1277dbbd - 10000 ℏ |
| 0.0.1004 - 0x9b9803be55a9886fae45bbc563157078e0368ad888acf2ac6f1b66952f5ba81c - 10000 ℏ |
| 0.0.1005 - 0x5f8a26c79e43cdb57afcff0f76d60c1ea8131ee02dce26876c0ac4e8a4a022a8 - 10000 ℏ |
| 0.0.1006 - 0x545beaf338839c2ecf53b1f42224351785477a533be4c8a922828c34ab54531f - 10000 ℏ |
| 0.0.1007 - 0x07c8c0238c1fb100dedd14f57477bd6879b4764aeb4ef352b6485dce32d7f91f - 10000 ℏ |
| 0.0.1008 - 0x6ae118c5e8d5ac1e5fcac6489dbcc2089c3f2121d7201d7b32614fa6527439da - 10000 ℏ |
| 0.0.1009 - 0x66a3a546c9f13df322f04b25011ed60c7c2760d60798dc6150f80c79cd925279 - 10000 ℏ |
| 0.0.1010 - 0x055b4213f2ee65a3b4a9b78285285b08b18208c84a956ed2bc075799d840332f - 10000 ℏ |
| 0.0.1011 - 0xc61b6e61ce18626d1b9be3ea8e4b27819623c9f9a4a82f54753db04625d99923 - 10000 ℏ |
|-----------------------------------------------------------------------------------------|

|--------------------------------------------------------------------------------------------------------------------------------------|
|------------------------------------------------| Accounts list (Alias ECDSA keys) |--------------------------------------------------|
|--------------------------------------------------------------------------------------------------------------------------------------|
|    id    |               public address               |                             private key                            | balance |
|--------------------------------------------------------------------------------------------------------------------------------------|
| 0.0.1012 - 0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69 - 0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524 - 10000 ℏ |
| 0.0.1013 - 0x05FbA803Be258049A27B820088bab1cAD2058871 - 0x2e1d968b041d84dd120a5860cee60cd83f9374ef527ca86996317ada3d0d03e7 - 10000 ℏ |
| 0.0.1014 - 0x927E41Ff8307835A1C081e0d7fD250625F2D4D0E - 0x45a5a7108a18dd5013cf2d5857a28144beadc9c70b3bdbd914e38df4e804b8d8 - 10000 ℏ |
| 0.0.1015 - 0xc37f417fA09933335240FCA72DD257BFBdE9C275 - 0x6e9d61a325be3f6675cf8b7676c70e4a004d2308e3e182370a41f5653d52c6bd - 10000 ℏ |
| 0.0.1016 - 0xD927017F5a6a7A92458b81468Dc71FCE6115B325 - 0x0b58b1bd44469ac9f813b5aeaf6213ddaea26720f0b2f133d08b6f234130a64f - 10000 ℏ |
| 0.0.1017 - 0x5C41A21F14cFe9808cBEc1d91b55Ba75ed327Eb6 - 0x95eac372e0f0df3b43740fa780e62458b2d2cc32d6a440877f1cc2a9ad0c35cc - 10000 ℏ |
| 0.0.1018 - 0xcdaD5844f865F379beA057fb435AEfeF38361B68 - 0x6c6e6727b40c8d4b616ab0d26af357af09337299f09c66704146e14236972106 - 10000 ℏ |
| 0.0.1019 - 0x6e5D3858f53FC66727188690946631bDE0466B1A - 0x5072e7aa1b03f531b4731a32a021f6a5d20d5ddc4e55acbb71ae202fc6f3a26d - 10000 ℏ |
| 0.0.1020 - 0x29cbb51A44fd332c14180b4D471FBBc6654b1657 - 0x60fe891f13824a2c1da20fb6a14e28fa353421191069ba6b6d09dd6c29b90eff - 10000 ℏ |
| 0.0.1021 - 0x17b2B8c63Fa35402088640e426c6709A254c7fFb - 0xeae4e00ece872dd14fb6dc7a04f390563c7d69d16326f2a703ec8e0934060cc7 - 10000 ℏ |
|--------------------------------------------------------------------------------------------------------------------------------------|

|-----------------------------------------------------------------------------------------|
|-----------------------------| Accounts list (ED25519 keys) |----------------------------|
|-----------------------------------------------------------------------------------------|
|    id    |                            private key                            |  balance |
|-----------------------------------------------------------------------------------------|
| 0.0.1022 - 0x87b64bffcbfb637e0feddb2a79c4635d579e593349bef3eace26ee448142f4af - 10000 ℏ |
| 0.0.1023 - 0x4a4f232e215f4244b9f54b3d3bee7ca8cd930dfb426f25423c405fa5a9a33683 - 10000 ℏ |
| 0.0.1024 - 0xa86553a24db0f3cbff2ec7c1252afbceb8642c553dfe828e804809bd1a282252 - 10000 ℏ |
| 0.0.1025 - 0xf2eb575dcfb61cbf7e0a21d317bd41052ff745a7fa3c01ea9fea032948c557d5 - 10000 ℏ |
| 0.0.1026 - 0x0422fbdaa3270bc20cdda469c272af37de833e24594af66236ce7269b6ee44d0 - 10000 ℏ |
| 0.0.1027 - 0x5af4dc6348dd64f24a74cb20180d5a520c1cd05d9c9bc1254cc81d2233c413b8 - 10000 ℏ |
| 0.0.1028 - 0xa14678f3afd919efe092c933655b038e5b31ed52e3f058777e6d5231190812a2 - 10000 ℏ |
| 0.0.1029 - 0xa0b092cd32b5262167e160947434125f0ba994ec05f0125aee70dd48837e7b65 - 10000 ℏ |
| 0.0.1030 - 0xefaf63b0b1a135f3e2dcf50214bb6acc3bce18afea343db6946923936e4b3a64 - 10000 ℏ |
| 0.0.1031 - 0xac8be199d260d22e1aeaabf7c10a6ea364ce2ee877ae4710fd8b57770ecb0f6c - 10000 ℏ |
|-----------------------------------------------------------------------------------------|

Local node has been successfully started in detached mode.
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
