### PR TITLE
fix: Mirror Node Web3 ChainID configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,6 +302,7 @@ services:
       - mirror-node
     environment:
       HEDERA_MIRROR_WEB3_DB_HOST: db
+      HEDERA_MIRROR_WEB3_EVM_NETWORK: OTHER
     ports:
       - "8545:8545"
     restart: unless-stopped


### PR DESCRIPTION
**Description**:
This PR aims to fix the mirror node web3 chainID to 298, which is the same as the consensus node. It was previously set to 296.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
