### PR TITLE
chore: bump network images and local node version

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=main-network-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.41.4
-HAVEGED_IMAGE_TAG=0.41.4
+NETWORK_NODE_IMAGE_TAG=0.43.3
+HAVEGED_IMAGE_TAG=0.43.3
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m
@@ -28,7 +28,7 @@ PYTHON_VERSION=python3.7
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.88.1
+MIRROR_IMAGE_TAG=0.92.0
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=postgres:14-alpine
@@ -44,7 +44,7 @@ MINIO_ROOT_PASSWORD=minioadmin
 
 #### JSON RPC Relay Prefixes & Tags ####
 RELAY_IMAGE_PREFIX=ghcr.io/hashgraph/
-RELAY_IMAGE_TAG=0.32.0
+RELAY_IMAGE_TAG=0.36.0
 
 #### JSON RPC Relay limits ####
 RELAY_MEM_LIMIT=512m

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -22,6 +22,9 @@ on:
       - opened
       - reopened
       - synchronize
+  push:
+    branches:
+      - main
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![Smoke Tests](https://github.com/hashgraph/hedera-local-node/actions/workflows/smoke-tests.yaml/badge.svg?branch=main)](https://github.com/hashgraph/hedera-local-node/actions/workflows/smoke-tests.yaml)[![npm (tag)](https://img.shields.io/npm/v/@hashgraph/hedera-local)](https://www.npmjs.com/package/@hashgraph/hedera-local)
+[![Smoke Tests](https://github.com/hashgraph/hedera-local-node/actions/workflows/flow-pull-request-checks.yaml/badge.svg?branch=main)](https://github.com/hashgraph/hedera-local-node/actions/workflows/flow-pull-request-checks.yaml)[![npm (tag)](https://img.shields.io/npm/v/@hashgraph/hedera-local)](https://www.npmjs.com/package/@hashgraph/hedera-local)
 [![Environment Variables](https://img.shields.io/badge/env-docs-green.svg)](docs/environment-variables.md)
 [![Made With](https://img.shields.io/badge/made_with-typescript-blue)](https://github.com/hashgraph/hederajson-rpc-relay/)
 [![License](https://img.shields.io/badge/license-apache2-blue.svg)](LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "hedera-local-node",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hedera-local-node",
-      "version": "2.15.1",
+      "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hashgraph/sdk": "^2.37.0",
+        "@hashgraph/sdk": "^2.38.0",
         "blessed": "^0.1.81",
         "blessed-terminal": "^0.1.22",
         "dockerode": "^4.0.0",
         "dotenv": "^16.3.1",
-        "ethers": "^6.8.0",
+        "ethers": "^6.8.1",
         "js-yaml": "^4.1.0",
         "rimraf": "^5.0.5",
         "semver": "^7.5.4",
@@ -22,7 +22,7 @@
         "yargs": "^17.7.2"
       },
       "bin": {
-        "hedera": "dist/index.js"
+        "hedera": "build/index.js"
       },
       "devDependencies": {
         "@types/blessed": "^0.1.24",
@@ -39,7 +39,7 @@
         "husky": "^8.0.0",
         "prettier": "^3.0.3",
         "ts-node": "^10.9.1",
-        "typescript": "^5.2.2"
+        "typescript": "^5.3.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -560,9 +560,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@hashgraph/cryptography": {
-      "version": "1.4.8-beta.3",
-      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.3.tgz",
-      "integrity": "sha512-ABmJOMr17ZeH8hf+SAKy+91SNdGjnfqTQlmm0LE4YFyT4Euo/YyIjyhCDQA2Oi+VBOC4p6CdRRa9vs3Q/Waxgg==",
+      "version": "1.4.8-beta.4",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.4.tgz",
+      "integrity": "sha512-43wpRuE6ML04dFNpNPHvEZTKlVT9+dOE7SxyQPMYunsFitJvlIDl1VvOXeOSGbVdsV+nDQQV7C9pZWRSV1e32g==",
       "dependencies": {
         "asn1js": "^3.0.5",
         "bignumber.js": "^9.1.1",
@@ -614,16 +614,16 @@
       }
     },
     "node_modules/@hashgraph/sdk": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.37.0.tgz",
-      "integrity": "sha512-QDEeTAcerKbp6lx3coKBt5Nu6TRuZWXIoT9yUV1HkIdRHvgEghEV59yI5iuJSxpOHJkShfSyigrr/NIuBQIeBw==",
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.38.0.tgz",
+      "integrity": "sha512-fe28I/xEAyaA1S8VrwR4oWGLonyjadD0sHyCbaO+9zPgpQXcM4wMeBZrbkia5riemY+adPHwrJ5FxASk3Rr3eg==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/rlp": "^5.7.0",
         "@grpc/grpc-js": "1.8.2",
-        "@hashgraph/cryptography": "1.4.8-beta.3",
+        "@hashgraph/cryptography": "1.4.8-beta.4",
         "@hashgraph/proto": "2.14.0-beta.2",
         "axios": "^1.3.1",
         "bignumber.js": "^9.1.1",
@@ -637,7 +637,7 @@
         "utf8": "^3.0.0"
       },
       "engines": {
-        "node": ">=10.17.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "expo": "^49.0.10"
@@ -2995,9 +2995,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.8.0.tgz",
-      "integrity": "sha512-zrFbmQRlraM+cU5mE4CZTLBurZTs2gdp2ld0nG/f3ecBK+x6lZ69KSxBqZ4NjclxwfTxl5LeNufcBbMsTdY53Q==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.8.1.tgz",
+      "integrity": "sha512-iEKm6zox5h1lDn6scuRWdIdFJUCGg3+/aQWu0F4K0GVyEZiktFkqrJbRjTn1FlYEPz7RKA707D6g5Kdk6j7Ljg==",
       "funding": [
         {
           "type": "individual",
@@ -6245,9 +6245,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-local-node",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {
@@ -46,15 +46,15 @@
     "husky": "^8.0.0",
     "prettier": "^3.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@hashgraph/sdk": "^2.37.0",
+    "@hashgraph/sdk": "^2.38.0",
     "blessed": "^0.1.81",
     "blessed-terminal": "^0.1.22",
     "dockerode": "^4.0.0",
     "dotenv": "^16.3.1",
-    "ethers": "^6.8.0",
+    "ethers": "^6.8.1",
     "js-yaml": "^4.1.0",
     "rimraf": "^5.0.5",
     "semver": "^7.5.4",

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.44.0-alpha.2"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.44.0-alpha.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.45.0-alpha.0"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.45.0-alpha.0"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.92.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.32.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.36.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "23.9.0"}
   ],
   "envConfiguration": [

--- a/src/configuration/mainnet.json
+++ b/src/configuration/mainnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.42.6"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.42.6"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.91.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.35.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.43.3"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.43.3"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.92.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.36.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "23.9.0"}
   ],
   "nodeConfiguration": {

--- a/src/configuration/previewnet.json
+++ b/src/configuration/previewnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.44.0-alpha.0"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.44.0-alpha.0"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.45.0-alpha.0"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.45.0-alpha.0"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.92.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.35.2"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.36.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "23.9.0"}
   ],
   "nodeConfiguration": {

--- a/src/configuration/testnet.json
+++ b/src/configuration/testnet.json
@@ -2,8 +2,8 @@
   "imageTagConfiguration": [
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.43.3"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.43.3"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.91.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.35.2"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.92.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.36.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "23.9.0"}
   ],
   "nodeConfiguration": {


### PR DESCRIPTION
**Description**:
This PR aims to bump the network images to the latest, as well as local-node network version to prepare it for release

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
