### PR TITLE
fix: build before publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint-fix": "eslint --fix src/**/*.ts",
     "pretty": "prettier --write 'src/**/*.ts'",
     "precommit": "npm run pretty",
-    "prepush": "npm run lint"
+    "prepush": "npm run lint",
+    "prepublishOnly": "npm run build"
   },
   "bin": {
     "hedera": "./build/index.js"


### PR DESCRIPTION
**Description**:
This PR adds an automatic build to the `npm publish` command to prevent accidental publishing of non-functioning releases to the package registry.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #470 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
