### PR TITLE
fix: Wrong startup account ids #474

### DIFF
--- a/src/state/AccountCreationState.ts
+++ b/src/state/AccountCreationState.ts
@@ -69,8 +69,11 @@ export class AccountCreationState implements IState{
 
     public async onStart(): Promise<void> {
         const currentArgv = this.cliService.getCurrentArgv();
-        const async = currentArgv.async;
-        this.blocklistedAccountsCount = await this.getBlocklistedAccountsCount();
+        const { async, blocklisting } = currentArgv;
+        if(blocklisting) {
+            this.blocklistedAccountsCount = await this.getBlocklistedAccountsCount();
+        }
+
         const mode = async ? `asynchronous` : `synchronous`
         const blockListedMessage = this.blocklistedAccountsCount > 0 ? `with ${this.blocklistedAccountsCount} blocklisted accounts` : ''
         this.logger.info(


### PR DESCRIPTION
**Description**:
Default startup generated accounts ids are off, so trying to use them will result in INVALID_SIGNATURE. The expected first account ID is 0.0.1003 while the actual one is 0.0.1002 and the rest are off by 1 as well.

**Related issue(s)**:

Fixes #
[Wrong startup account ids#474](https://github.com/hashgraph/hedera-local-node/issues/474)
