### PR TITLE
feat: add new error type and exit when needed

### DIFF
--- a/src/controller/StateController.ts
+++ b/src/controller/StateController.ts
@@ -64,7 +64,7 @@ export class StateController implements IOBserver{
         if (event === EventType.Finish) {
             await this.transitionToNextState();
         } else {
-            if (event === EventType.UnknownError) {
+            if (event === EventType.UnknownError || event === EventType.UnresolvableError) {
                 await new CleanUpState().onStart();
                 process.exit(1);
             } else {

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -67,6 +67,10 @@ export class InitState implements IState{
         // Check if docker is running and it's the correct version
         const isCorrectDockerComposeVersion = await this.dockerService.isCorrectDockerComposeVersion();
         const isDockerStarted = await this.dockerService.checkDocker();
+        if (!(isCorrectDockerComposeVersion && isDockerStarted)) {
+            this.observer!.update(EventType.UnresolvableError);
+            return;
+        }
         await this.dockerService.isPortInUse(NECESSARY_PORTS.concat(OPTIONAL_PORTS));
 
         this.logger.info(`Setting configuration for ${this.cliOptions.network} network with latest images on host ${this.cliOptions.host} with dev mode turned ${this.cliOptions.devMode ? 'on' : 'off'} using ${this.cliOptions.fullMode? 'full': 'turbo'} mode in ${this.cliOptions.multiNode? 'multi' : 'single'} node configuration...`, this.stateName);

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -21,5 +21,6 @@
 export enum EventType{
     Finish,
     DockerError,
-    UnknownError
+    UnknownError,
+    UnresolvableError
 }


### PR DESCRIPTION
**Description**:
This PR adds `UnresolvableError` type, when something like docker is not running or is wrong version occurred.

**Related issue(s)**:

Fixes #486 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
