### PR TITLE
fix: Running local-node occasionally fails on InitState

### DIFF
--- a/src/services/DockerService.ts
+++ b/src/services/DockerService.ts
@@ -199,7 +199,7 @@ export class DockerService implements IService{
     public async checkDockerResources(isMultiNodeMode: boolean) {
       this.logger.info('Checking docker resources...', this.serviceName);
       const resultDockerInfoCommand = await shell.exec(
-        'docker system info --format=json',
+        "docker system info --format='{{json .}}'",
         { silent: true }
       );
       


### PR DESCRIPTION
**Description**:
Trying to run local-node results in error in `docker system info` command on old versions.
Changing the format pattern resolves this issue

**Related issue(s)**:
Running local-node occasionally fails on InitState
[#503](https://github.com/hashgraph/hedera-local-node/issues/503)