### PR TITLE
feat: add options for custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Available commands:
             --async to enable or disable asynchronous creation of accounts.
             --b or --blocklist to enable or disable account blocklisting. Depending on how many private keys are blocklisted, this will affect the generated on startup accounts.
             --enable-debug  Enable or disable debugging of the local node [boolean] [default: false]
+            --network-tag Select custom network node tag [string] [defaults: predefined selected configuration]
+            --mirror-tag Select custom mirror node tag [string] [defaults: predefined selected configuration]
+            --relay-tag Select custom hedera-json-rpc relay tag [string] [defaults: predefined selected configuration]
             --workdir       Path to the working directory for local node [string] [default: "[USER APP DATA]/hedera-local"]
     stop - Stops the local hedera network and delete all the existing data.
     restart - Restart the local hedera network.

--- a/src/services/CLIService.ts
+++ b/src/services/CLIService.ts
@@ -87,6 +87,9 @@ export class CLIService implements IService{
         CLIService.userComposeDirOption(yargs);
         CLIService.blocklistingOption(yargs);
         CLIService.enableDebugOption(yargs);
+        CLIService.selectNetworkTag(yargs);
+        CLIService.selectMirrorTag(yargs);
+        CLIService.selectRelayTag(yargs);
     }
 
     /**
@@ -152,8 +155,10 @@ export class CLIService implements IService{
         const verbose = CLIService.resolveVerboseLevel(argv.verbose as string);
         const timestamp = argv.timestamp as string;
         const enableDebug = argv.enableDebug as boolean;
+        const networkTag = argv.networkTag as string;
+        const mirrorTag = argv.mirrorTag as string;
+        const relayTag = argv.relayTag as string;
         const workDir = FileSystemUtils.parseWorkDir(argv.workdir as string);
-
         const currentArgv: CLIOptions = {
             accounts,
             async,
@@ -172,6 +177,9 @@ export class CLIService implements IService{
             verbose,
             timestamp,
             enableDebug,
+            networkTag,
+            mirrorTag,
+            relayTag,
             workDir,
         };
 
@@ -522,7 +530,61 @@ export class CLIService implements IService{
             describe: 'Enable or disable debugging of the local node',
             demandOption: false,
             default: false
-          });
+        });
+    }
+
+    /**
+     * Adds the 'network-tag' option to the command line arguments.
+     * This option is a string that enables usage of custom network tag.
+     * It is not required and defaults to predefined configuration.
+     * 
+     * @param {yargs.Argv<{}>} yargs - The yargs instance to which the option is added.
+     * @private
+     * @static
+     */
+    private static selectNetworkTag(yargs: Argv<{}>): void {
+        yargs.option('network-tag', {
+            type: 'string',
+            describe: 'Select custom network node tag',
+            demandOption: false,
+            default: 'default'
+        });
+    }
+
+    /**
+     * Adds the 'mirror-tag' option to the command line arguments.
+     * This option is a string that enables usage of custom mirror-node tag.
+     * It is not required and defaults to predefined configuration.
+     * 
+     * @param {yargs.Argv<{}>} yargs - The yargs instance to which the option is added.
+     * @private
+     * @static
+     */
+    private static selectMirrorTag(yargs: Argv<{}>): void {
+        yargs.option('mirror-tag', {
+            type: 'string',
+            describe: 'Select custom mirror-node tag',
+            demandOption: false,
+            default: 'default'
+        });
+    }
+
+    /**
+     * Adds the 'mirror-tag' option to the command line arguments.
+     * This option is a string that enables usage of custom mirror-node tag.
+     * It is not required and defaults to predefined configuration.
+     * 
+     * @param {yargs.Argv<{}>} yargs - The yargs instance to which the option is added.
+     * @private
+     * @static
+     */
+    private static selectRelayTag(yargs: Argv<{}>): void {
+        yargs.option('relay-tag', {
+            type: 'string',
+            describe: 'Select custom hedera-json-rpc relay tag',
+            demandOption: false,
+            default: 'default'
+        });
     }
     
     /**

--- a/src/services/CLIService.ts
+++ b/src/services/CLIService.ts
@@ -547,7 +547,7 @@ export class CLIService implements IService{
             type: 'string',
             describe: 'Select custom network node tag',
             demandOption: false,
-            default: 'default'
+            default: ''
         });
     }
 
@@ -565,7 +565,7 @@ export class CLIService implements IService{
             type: 'string',
             describe: 'Select custom mirror-node tag',
             demandOption: false,
-            default: 'default'
+            default: ''
         });
     }
 
@@ -583,7 +583,7 @@ export class CLIService implements IService{
             type: 'string',
             describe: 'Select custom hedera-json-rpc relay tag',
             demandOption: false,
-            default: 'default'
+            default: ''
         });
     }
     

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -159,8 +159,18 @@ export class InitState implements IState{
      */
     private configureEnvVariables(imageTagConfiguration: Array<Configuration>, envConfiguration: Array<Configuration> | undefined): void {
         imageTagConfiguration.forEach(variable => {
-            process.env[variable.key] = variable.value;
-            this.logger.trace(`Environment variable ${variable.key} will be set to ${variable.value}.`, this.stateName);
+            const node = variable.key;
+            let tag = variable.value;
+            if (this.cliOptions.networkTag !== 'default' && (node === "NETWORK_NODE_IMAGE_TAG" || node === "HAVEGED_IMAGE_TAG")) {
+                tag = this.cliOptions.networkTag;
+            } else if(this.cliOptions.mirrorTag !== 'default' && node === "MIRROR_IMAGE_TAG") {
+                tag = this.cliOptions.mirrorTag;
+            } else if(this.cliOptions.relayTag !== 'default' && node === "RELAY_IMAGE_TAG") {
+                tag = this.cliOptions.relayTag;
+            }
+
+            this.logger.trace(`Environment variable ${node} will be set to ${tag}.`, this.stateName);
+            process.env[node] = tag;
         });
 
         if (!envConfiguration) {

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -161,11 +161,11 @@ export class InitState implements IState{
         imageTagConfiguration.forEach(variable => {
             const node = variable.key;
             let tag = variable.value;
-            if (this.cliOptions.networkTag !== 'default' && (node === "NETWORK_NODE_IMAGE_TAG" || node === "HAVEGED_IMAGE_TAG")) {
+            if (this.cliOptions.networkTag && (node === "NETWORK_NODE_IMAGE_TAG" || node === "HAVEGED_IMAGE_TAG")) {
                 tag = this.cliOptions.networkTag;
-            } else if(this.cliOptions.mirrorTag !== 'default' && node === "MIRROR_IMAGE_TAG") {
+            } else if(this.cliOptions.mirrorTag && node === "MIRROR_IMAGE_TAG") {
                 tag = this.cliOptions.mirrorTag;
-            } else if(this.cliOptions.relayTag !== 'default' && node === "RELAY_IMAGE_TAG") {
+            } else if(this.cliOptions.relayTag && node === "RELAY_IMAGE_TAG") {
                 tag = this.cliOptions.relayTag;
             }
 

--- a/src/types/CLIOptions.ts
+++ b/src/types/CLIOptions.ts
@@ -61,5 +61,8 @@ export interface CLIOptions {
     verbose: number,
     timestamp: string,
     enableDebug: boolean,
+    networkTag: string,
+    mirrorTag: string,
+    relayTag: string,
     workDir: string,
 }


### PR DESCRIPTION
**Description**:
This PR adds 3 new options for selecting custom images for network, mirror-node and/or relay. This will allow for easier testing with different tags in CI.

**Related issue(s)**:

Fixes #525 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
