### PR TITLE
fix: Moves while loop to a function and stub it in the unit tests for AttаchState

### DIFF
--- a/src/state/AttachState.ts
+++ b/src/state/AttachState.ts
@@ -48,6 +48,11 @@ export class AttachState implements IState{
      * The name of the state.
      */
     private stateName: string;
+
+    /**
+     * Timeout for updateStatusBoard
+     */
+    private timeOut: number = 10000;
     
     /**
      * Represents the AttachState class.
@@ -134,7 +139,7 @@ export class AttachState implements IState{
       let i = 0;
       while (i++ < this.loopIterations()) {
         await this.logger.updateStatusBoard();
-        await new Promise((resolve) => setTimeout(resolve, 10000));
+        await new Promise((resolve) => setTimeout(resolve, this.timeOut));
       }
     }
 

--- a/src/state/AttachState.ts
+++ b/src/state/AttachState.ts
@@ -87,11 +87,7 @@ export class AttachState implements IState{
         await this.attachContainerLogs(MIRROR_NODE_LABEL);
         await this.attachContainerLogs(RELAY_LABEL);
 
-        let i = 0;
-        while (i++ < this.loopIterations()) {
-          await this.logger.updateStatusBoard();
-          await new Promise((resolve) => setTimeout(resolve, 10000));
-        }
+        await this.continuouslyUpdateStatusBoard();
     }
 
     /**
@@ -132,6 +128,14 @@ export class AttachState implements IState{
             });
           }
         );
+    }
+
+    private async continuouslyUpdateStatusBoard(): Promise<void> {
+      let i = 0;
+      while (i++ < this.loopIterations()) {
+        await this.logger.updateStatusBoard();
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+      }
     }
 
     private loopIterations(): number {

--- a/test/unit/states/AttachState.spec.ts
+++ b/test/unit/states/AttachState.spec.ts
@@ -1,24 +1,22 @@
 import { expect } from 'chai';
-import sinon, { SinonSandbox, SinonStubbedInstance } from 'sinon';
+import sinon, { SinonSandbox, SinonStub, SinonStubbedInstance } from 'sinon';
 import { AttachState } from '../../../src/state/AttachState';
 import { IOBserver } from '../../../src/controller/IObserver';
 import { CLIService } from '../../../src/services/CLIService';
 import { DockerService } from '../../../src/services/DockerService';
-import { LoggerService } from '../../../src/services/LoggerService';
 import { EventType } from '../../../src/types/EventType';
 import { getTestBed } from '../testBed';
 
 describe('AttachState', () => {
   let attachState: AttachState,
-      loggerService: SinonStubbedInstance<LoggerService>,
       dockerService: SinonStubbedInstance<DockerService>,
       cliService: SinonStubbedInstance<CLIService>,
-      testSandbox: SinonSandbox;
+      testSandbox: SinonSandbox,
+      continuouslyUpdateStatusBoardStub: SinonStub;;
 
   before(() => {
     const {
         sandbox,
-        loggerServiceStub,
         dockerServiceStub,
         cliServiceStub
     } = getTestBed({
@@ -26,9 +24,10 @@ describe('AttachState', () => {
     });
 
     dockerService = dockerServiceStub
-    loggerService = loggerServiceStub
     cliService = cliServiceStub
     testSandbox = sandbox
+
+    continuouslyUpdateStatusBoardStub = testSandbox.stub(AttachState.prototype, <any>'continuouslyUpdateStatusBoard');
 
     // Create an instance of AttachState
     attachState = new AttachState();
@@ -58,22 +57,18 @@ describe('AttachState', () => {
         detached: false
       } as any);
       const attachContainerLogsStub = testSandbox.stub(AttachState.prototype, <any>'attachContainerLogs');
-      const iterations = testSandbox.stub(AttachState.prototype, <any>'loopIterations');
-      iterations.returns(2);
-
       await attachState.onStart();
 
       expect(attachContainerLogsStub.calledThrice).to.be.true;
       expect(attachContainerLogsStub.firstCall.calledWithExactly("network-node")).to.be.true;
       expect(attachContainerLogsStub.secondCall.calledWithExactly("mirror-node-rest")).to.be.true;
       expect(attachContainerLogsStub.thirdCall.calledWithExactly("json-rpc-relay")).to.be.true;
-      testSandbox.assert.calledTwice(loggerService.updateStatusBoard);
+      testSandbox.assert.called(continuouslyUpdateStatusBoardStub);
 
       attachContainerLogsStub.restore();
-      iterations.restore();
-    }).timeout(25000);
+    });
 
-    it('should not call attachContainerLogs when detached', async () => {
+    it('should call observer update attachContainerLogs when detached', async () => {
       (attachState as any).observer = { update: testSandbox.stub()};
       cliService.getCurrentArgv.returns({
         async: false,
@@ -84,15 +79,14 @@ describe('AttachState', () => {
         detached: true
       } as any);
       const attachContainerLogsStub = testSandbox.stub(AttachState.prototype, <any>'attachContainerLogs');
-      const iterations = testSandbox.stub(AttachState.prototype, <any>'loopIterations');
-      iterations.returns(2);
 
       await attachState.onStart();
 
+      testSandbox.assert.called(continuouslyUpdateStatusBoardStub);
       testSandbox.assert.calledOnceWithExactly(attachState.observer?.update, EventType.Finish);
+
       attachContainerLogsStub.restore();
-      iterations.restore();
-    }).timeout(25000);
+    });
   });
 
   describe('attachContainerLogs', () => {
@@ -112,8 +106,6 @@ describe('AttachState', () => {
         modem: { demuxStream: demuxSpy },
       } as any);
       const attachContainerLogsStub = testSandbox.stub(AttachState.prototype, <any>'attachContainerLogs');
-      const iterations = testSandbox.stub(AttachState.prototype, <any>'loopIterations');
-      iterations.returns(2);
       attachContainerLogsStub.withArgs("mirror-node-rest").resolves();
       attachContainerLogsStub.withArgs("json-rpc-relay").resolves();
       attachContainerLogsStub.callThrough();
@@ -122,9 +114,9 @@ describe('AttachState', () => {
 
       testSandbox.assert.calledOnce(dockerService.getContainer);
       const spy1 = dockerService.getContainer.getCall(0);
-
+      testSandbox.assert.called(continuouslyUpdateStatusBoardStub);
       testSandbox.assert.calledWithExactly(spy1, "network-node");
       testSandbox.assert.calledOnce(logsSpy);
-    }).timeout(25000);
+    });
   });
 });


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR changes the onStart method in the AttachState class.
So far we had a while loop in the onStart, which was updating the statusBoard. This made testing slow and not efficient.
The while was moved to a separate function, which can be stubbed, therefore supporting better testing
**Related issue(s)**:

Fixes #538 


**Checklist**

- [x] Tested (unit, integration, etc.)
