### PR TITLE
fix: Updated all configurations 

### DIFF
--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,6 +1,6 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.0-alpha.3"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.0-alpha.4"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.47.0-alpha.0"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.98.0-SNAPSHOT"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.39.0"},

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,6 +1,6 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.0-alpha.0"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.0-alpha.3"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.47.0-alpha.0"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.98.0-SNAPSHOT"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.39.0"},

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.0-alpha.4"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.47.0-alpha.0"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.98.0-SNAPSHOT"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.39.0"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.47.0-alpha.4"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.99.0-SNAPSHOT"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.40.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "23.9.0"}
   ],
   "envConfiguration": [

--- a/src/configuration/mainnet.json
+++ b/src/configuration/mainnet.json
@@ -2,8 +2,8 @@
   "imageTagConfiguration": [
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.45.2"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.45.2"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.96.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.39.0"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.97.1"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.40.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "23.9.0"}
   ],
   "nodeConfiguration": {

--- a/src/configuration/previewnet.json
+++ b/src/configuration/previewnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.0-alpha.0"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.47.0-alpha.0"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.0-alpha.4"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.47.0-alpha.4"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.97.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.39.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.40.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "23.9.0"}
   ],
   "nodeConfiguration": {

--- a/src/configuration/testnet.json
+++ b/src/configuration/testnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.46.2"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.46.2"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.97.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.39.0"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.46.3"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.46.3"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.97.1"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.40.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "23.9.0"}
   ],
   "nodeConfiguration": {


### PR DESCRIPTION
Set network node version to `0.47.0-alpha.3` to include HIP-844 changes

**Related issue(s)**:

Fixes #2086 in the Hedera JSON RPC Relay

