### PR TITLE
fix: make redis port necessary

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,8 +41,8 @@ export const MIRROR_NODE_LABEL = "mirror-node-rest";
 export const RELAY_LABEL = "json-rpc-relay";
 export const IS_WINDOWS = process.platform === "win32";
 export const UNKNOWN_VERSION = "Unknown";
-export const NECESSARY_PORTS = [5551, 8545, 5600, 5433, 50211, 8082];
-export const OPTIONAL_PORTS = [7546, 8080, 6379, 3000];
+export const NECESSARY_PORTS = [5551, 8545, 5600, 5433, 50211, 8082, 6379];
+export const OPTIONAL_PORTS = [7546, 8080, 3000];
 export const EVM_ADDRESSES_BLOCKLIST_FILE_RELATIVE_PATH = '../../compose-network/network-node'
 export const RELATIVE_TMP_DIR_PATH = 'services/record-parser/temp';
 export const RELATIVE_RECORDS_DIR_PATH = 'network-logs/node/recordStreams/record0.0.3';


### PR DESCRIPTION
**Description**:
Makes the port `6379` necessary insted of optional, because the local node is unable to start properly if it is already in use.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
