### PR TITLE
chore: update network images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-local",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/sdk": "^2.43.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.0-alpha.0"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.0-alpha.0"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.101.0-rc3"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.44.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.0-alpha.3"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.0-alpha.3"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.102.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.45.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.3.0"}
   ],
   "envConfiguration": [

--- a/src/configuration/mainnet.json
+++ b/src/configuration/mainnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.46.3"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.46.3"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.100.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.44.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.4"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.47.4"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.101.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.45.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.3.0"}
   ],
   "nodeConfiguration": {

--- a/src/configuration/previewnet.json
+++ b/src/configuration/previewnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.48.0-alpha.3"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.48.0-alpha.3"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.101.0-rc3"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.44.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.0-alpha.3"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.0-alpha.3"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.102.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.45.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.3.0"}
   ],
   "nodeConfiguration": {

--- a/src/configuration/testnet.json
+++ b/src/configuration/testnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.47.3"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.47.3"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.100.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.44.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.48.0"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.48.0"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.102.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.45.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.3.0"}
   ],
   "nodeConfiguration": {


### PR DESCRIPTION
**Description**:
This PR aims to update the network images and bump local-node version to 2.22.0

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
