### PR TITLE
feat: Add CLI option for persistTransactionBytes

### DIFF
--- a/compose-network/mirror-node/application.yml
+++ b/compose-network/mirror-node/application.yml
@@ -8,6 +8,9 @@ hedera:
       parser:
         record:
           entity:
+            persist:
+              transactionBytes: false
+              transactionRecordBytes: false
             redis:
               enabled: false
           sidecar:

--- a/src/services/CLIService.ts
+++ b/src/services/CLIService.ts
@@ -161,6 +161,7 @@ export class CLIService implements IService{
         const relayTag = argv.relayTag as string;
         const workDir = FileSystemUtils.parseWorkDir(argv.workdir as string);
         const createInitialResources = argv.createInitialResources as boolean;
+        const persistTransactionBytes = argv.persistTransactionBytes as boolean;
         const currentArgv: CLIOptions = {
             accounts,
             async,
@@ -183,7 +184,8 @@ export class CLIService implements IService{
             mirrorTag,
             relayTag,
             workDir,
-            createInitialResources
+            createInitialResources,
+            persistTransactionBytes,
         };
 
         return currentArgv;

--- a/src/types/CLIOptions.ts
+++ b/src/types/CLIOptions.ts
@@ -47,6 +47,7 @@ import { NetworkType } from './NetworkType';
  * @property {string} relayTag - The tag for the relay.
  * @property {string} workDir - The working directory.
  * @property {boolean} createInitialResources - Whether to create initial resources.
+ * @property {boolean} persistTransactionBytes - Whether to persist transaction bytes.
  */
 export interface CLIOptions {
     accounts: number,
@@ -71,4 +72,5 @@ export interface CLIOptions {
     relayTag: string,
     workDir: string,
     createInitialResources: boolean,
+    persistTransactionBytes: boolean,
 }

--- a/test/unit/states/InitState.spec.ts
+++ b/test/unit/states/InitState.spec.ts
@@ -24,20 +24,20 @@ import yaml from 'js-yaml';
 import { join } from 'path';
 import { SinonSandbox, SinonSpy, SinonStub, SinonStubbedInstance } from 'sinon';
 import {
-    APPLICATION_YML_RELATIVE_PATH,
-    INIT_STATE_BOOTSTRAPPED_PROP_SET,
-    INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH,
-    INIT_STATE_INIT_MESSAGE,
-    INIT_STATE_MIRROR_PROP_SET,
-    INIT_STATE_NO_ENV_VAR_CONFIGURED,
-    INIT_STATE_NO_NODE_CONF_NEEDED,
-    INIT_STATE_RELAY_LIMITS_DISABLED,
-    INIT_STATE_START_DOCKER_CHECK,
-    INIT_STATE_STARTING_MESSAGE,
-    NECESSARY_PORTS,
-    NETWORK_NODE_CONFIG_DIR_PATH,
-    OPTIONAL_PORTS,
-    RECORD_PARSER_SOURCE_REL_PATH
+  APPLICATION_YML_RELATIVE_PATH,
+  INIT_STATE_BOOTSTRAPPED_PROP_SET,
+  INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH,
+  INIT_STATE_INIT_MESSAGE,
+  INIT_STATE_MIRROR_PROP_SET,
+  INIT_STATE_NO_ENV_VAR_CONFIGURED,
+  INIT_STATE_NO_NODE_CONF_NEEDED,
+  INIT_STATE_RELAY_LIMITS_DISABLED,
+  INIT_STATE_START_DOCKER_CHECK,
+  INIT_STATE_STARTING_MESSAGE,
+  NECESSARY_PORTS,
+  NETWORK_NODE_CONFIG_DIR_PATH,
+  OPTIONAL_PORTS,
+  RECORD_PARSER_SOURCE_REL_PATH
 } from '../../../src/constants';
 import { ConfigurationData } from '../../../src/data/ConfigurationData';
 import { CLIService } from '../../../src/services/CLIService';
@@ -50,7 +50,7 @@ import { getTestBed } from '../testBed';
 
 describe('InitState tests', () => {
     let initState: InitState,
-        testSandbox: SinonSandbox, 
+        testSandbox: SinonSandbox,
         loggerService: SinonStubbedInstance<LoggerService>,
         serviceLocator: SinonStub,
         cliService: SinonStubbedInstance<CLIService>,
@@ -89,7 +89,7 @@ describe('InitState tests', () => {
     }
 
     before(() => {
-        const { 
+        const {
             sandbox,
             loggerServiceStub,
             serviceLocatorStub,
@@ -104,7 +104,7 @@ describe('InitState tests', () => {
             mirrorTag: 'test-mirror-tag',
             relayTag: 'test-relay-tag',
         });
-    
+
         testSandbox = sandbox
         dockerService = dockerServiceStub
         cliService = cliServiceStub
@@ -155,7 +155,7 @@ describe('InitState tests', () => {
         testSandbox.assert.calledOnce(dockerService.isCorrectDockerComposeVersion);
         testSandbox.assert.calledOnce(dockerService.checkDocker);
         testSandbox.assert.calledOnce(dockerService.checkDockerResources);
-        
+
         testSandbox.assert.calledOnceWithExactly(dockerService.isPortInUse, NECESSARY_PORTS.concat(OPTIONAL_PORTS));
         testSandbox.assert.calledWith(observerSpy, EventType.Finish);
         testSandbox.assert.calledOnce(prepareWorkDirectoryStub);
@@ -179,7 +179,7 @@ describe('InitState tests', () => {
         testSandbox.assert.calledOnce(dockerService.checkDockerResources);
 
         testSandbox.assert.calledWith(observerSpy, EventType.UnresolvableError);
-        
+
         testSandbox.assert.notCalled(dockerService.isPortInUse);
         testSandbox.assert.notCalled(loggerService.initializeTerminalUI);
     })
@@ -240,7 +240,7 @@ describe('InitState tests', () => {
         afterEach(() => {
             onStartStub.restore()
         })
-        
+
         it('should execute "prepareWorkDirectory" as expected', async () => {
             prepareWorkDirectoryStub.restore()
 
@@ -250,7 +250,7 @@ describe('InitState tests', () => {
             testSandbox.assert.calledWithExactly(loggerService.info, "Local Node Working directory set to testDir", InitState.name);
             testSandbox.assert.calledOnceWithExactly(createEphemeralDirectoriesStub, "testDir");
             testSandbox.assert.calledOnceWithExactly(copyPathsStub, configFiles);
-            
+
             prepareWorkDirectoryStub = testSandbox.stub(initState as any, 'prepareWorkDirectory')
         })
 
@@ -397,7 +397,7 @@ describe('InitState tests', () => {
                 configureMirrorNodePropertiesStub = testSandbox.stub(initState as any, 'configureMirrorNodeProperties');
             })
 
-            it('should execute "configureMirrorNodeProperties" as write to file', async () => {
+            it('should set the persist properties for transactionBytes and transactionRecordBytes to true', async () => {
                 await initState.onStart();
                 testSandbox.assert.calledOnceWithExactly(loggerService.info, INIT_STATE_MIRROR_PROP_SET, InitState.name);
                 testSandbox.assert.called(fsReadFileSync);


### PR DESCRIPTION
**Description**:

This PR:
- adds a new CLI flag `--persistTransactionBytes` which will set these two properties to `true` for the mirror-node:
  - `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`
  - `hedera.mirror.importer.parser.record.entity.persist.transactionRecordBytes`

**Related issue(s)**:

Fixes #619 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
