### PR TITLE
chore: Bump network node version to 0.49.7

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=main-network-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.49.6
-HAVEGED_IMAGE_TAG=0.49.6
+NETWORK_NODE_IMAGE_TAG=0.49.7
+HAVEGED_IMAGE_TAG=0.49.7
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m

--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ PYTHON_VERSION=python3.7
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.103.0
+MIRROR_IMAGE_TAG=0.104.0
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=postgres:14-alpine
@@ -45,7 +45,7 @@ MINIO_ROOT_PASSWORD=minioadmin
 
 #### JSON RPC Relay Prefixes & Tags ####
 RELAY_IMAGE_PREFIX=ghcr.io/hashgraph/
-RELAY_IMAGE_TAG=0.46.1
+RELAY_IMAGE_TAG=0.47.0
 
 #### JSON RPC Relay limits ####
 RELAY_MEM_LIMIT=768m

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,7 +1,7 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.6"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.6"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.7"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.7"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.103.0"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.47.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -2,7 +2,7 @@
   "imageTagConfiguration": [
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.7"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.7"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.103.0"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.104.0"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.47.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],

--- a/src/configuration/mainnet.json
+++ b/src/configuration/mainnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.48.1"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.48.1"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.7"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.7"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.102.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.46.1"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.47.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],
   "nodeConfiguration": {

--- a/src/configuration/mainnet.json
+++ b/src/configuration/mainnet.json
@@ -2,7 +2,7 @@
   "imageTagConfiguration": [
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.7"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.7"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.102.0"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.104.0"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.47.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],

--- a/src/configuration/previewnet.json
+++ b/src/configuration/previewnet.json
@@ -2,7 +2,7 @@
   "imageTagConfiguration": [
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.50.0-alpha.1"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.50.0-alpha.1"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.102.0-rc1"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.105.0-rc2"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.48.0-rc2"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],

--- a/src/configuration/previewnet.json
+++ b/src/configuration/previewnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.5"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.5"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.103.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.46.1"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.50.0-alpha.1"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.50.0-alpha.1"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.102.0-rc1"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.48.0-rc2"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],
   "nodeConfiguration": {

--- a/src/configuration/testnet.json
+++ b/src/configuration/testnet.json
@@ -2,7 +2,7 @@
   "imageTagConfiguration": [
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.7"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.7"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.101.0"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.104.0"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.48.0-rc2"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],

--- a/src/configuration/testnet.json
+++ b/src/configuration/testnet.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.5"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.5"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.103.0"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.46.1"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.49.7"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.49.7"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.101.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.48.0-rc2"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],
   "nodeConfiguration": {


### PR DESCRIPTION
**Description**:
- Bumps the versions for services, mirror node and relay images for all network configurations.
- Bumps the package version number

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
