### PR TITLE
feat: expose opcodes endpoint by default

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=main-network-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.50.0
-HAVEGED_IMAGE_TAG=0.50.0
+NETWORK_NODE_IMAGE_TAG=0.51.0-alpha.4
+HAVEGED_IMAGE_TAG=0.51.0-alpha.4
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m
@@ -29,7 +29,7 @@ PYTHON_VERSION=python3.7
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.104.0
+MIRROR_IMAGE_TAG=0.107.0-rc1
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=postgres:14-alpine
@@ -45,7 +45,7 @@ MINIO_ROOT_PASSWORD=minioadmin
 
 #### JSON RPC Relay Prefixes & Tags ####
 RELAY_IMAGE_PREFIX=ghcr.io/hashgraph/
-RELAY_IMAGE_TAG=0.47.0
+RELAY_IMAGE_TAG=0.49.0
 
 #### JSON RPC Relay limits ####
 RELAY_MEM_LIMIT=768m
@@ -89,7 +89,7 @@ ENVOY_IMAGE_TAG=v1.22.0
 
 #### Mirror Node Explorer Prefixes & Tags ####
 MIRROR_NODE_EXPLORER_IMAGE_PREFIX=gcr.io/hedera-registry/
-MIRROR_NODE_EXPLORER_IMAGE_TAG=24.3.0
+MIRROR_NODE_EXPLORER_IMAGE_TAG=24.4.0
 
 ### Mirror Node Explorer ###
 DOCKER_LOCAL_MIRROR_NODE_MENU_NAME=LOCALNET

--- a/compose-network/mirror-node/application.yml
+++ b/compose-network/mirror-node/application.yml
@@ -59,3 +59,7 @@ hedera:
       operator:
         accountId: 0.0.2
         privateKey: 302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137
+    web3:
+      opcode:
+        tracer:
+          enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,6 +309,8 @@ services:
       - "8545:8545"
     restart: unless-stopped
     tty: true
+    volumes:
+      - "${MIRROR_NODE_CONFIG_PATH}/compose-network/mirror-node/application.yml:/usr/etc/hedera-mirror-web3/application.yml"
 
   monitor:
     image: "${MIRROR_IMAGE_PREFIX}hedera-mirror-monitor:${MIRROR_IMAGE_TAG}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,6 +305,7 @@ services:
     environment:
       HEDERA_MIRROR_WEB3_DB_HOST: db
       HEDERA_MIRROR_WEB3_EVM_NETWORK: OTHER
+      SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-web3/
     ports:
       - "8545:8545"
     restart: unless-stopped

--- a/docs/custom-sub-system-configs.md
+++ b/docs/custom-sub-system-configs.md
@@ -82,3 +82,11 @@ The following table lists the available properties along with their default valu
 | `hedera.mirror.monitor.nodes[].host`                               | ""       | The main node's hostname  |
 | `hedera.mirror.monitor.operator.accountId`                         | ""       | Operator account ID used to pay for transactions                                                                                                                                                            |
 | `hedera.mirror.monitor.operator.privateKey`                        | ""       | Operator ED25519 private key used to sign transactions in hex encoded DER format |
+
+## Web3 API
+
+The following table lists the available properties along with their default values.
+
+| Name                                       | Default | Description                                                                        |
+|--------------------------------------------|---------|------------------------------------------------------------------------------------|
+| `hedera.mirror.web3.opcode.tracer.enabled` | true    | Whether the `/contracts/results/{transactionIdOrHash}/opcodes` endpoint is exposed |

--- a/test/unit/states/InitState.spec.ts
+++ b/test/unit/states/InitState.spec.ts
@@ -24,20 +24,20 @@ import yaml from 'js-yaml';
 import { join } from 'path';
 import { SinonSandbox, SinonSpy, SinonStub, SinonStubbedInstance } from 'sinon';
 import {
-  APPLICATION_YML_RELATIVE_PATH,
-  INIT_STATE_BOOTSTRAPPED_PROP_SET,
-  INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH,
-  INIT_STATE_INIT_MESSAGE,
-  INIT_STATE_MIRROR_PROP_SET,
-  INIT_STATE_NO_ENV_VAR_CONFIGURED,
-  INIT_STATE_NO_NODE_CONF_NEEDED,
-  INIT_STATE_RELAY_LIMITS_DISABLED,
-  INIT_STATE_START_DOCKER_CHECK,
-  INIT_STATE_STARTING_MESSAGE,
-  NECESSARY_PORTS,
-  NETWORK_NODE_CONFIG_DIR_PATH,
-  OPTIONAL_PORTS,
-  RECORD_PARSER_SOURCE_REL_PATH
+    APPLICATION_YML_RELATIVE_PATH,
+    INIT_STATE_BOOTSTRAPPED_PROP_SET,
+    INIT_STATE_CONFIGURING_ENV_VARIABLES_FINISH,
+    INIT_STATE_INIT_MESSAGE,
+    INIT_STATE_MIRROR_PROP_SET,
+    INIT_STATE_NO_ENV_VAR_CONFIGURED,
+    INIT_STATE_NO_NODE_CONF_NEEDED,
+    INIT_STATE_RELAY_LIMITS_DISABLED,
+    INIT_STATE_START_DOCKER_CHECK,
+    INIT_STATE_STARTING_MESSAGE,
+    NECESSARY_PORTS,
+    NETWORK_NODE_CONFIG_DIR_PATH,
+    OPTIONAL_PORTS,
+    RECORD_PARSER_SOURCE_REL_PATH
 } from '../../../src/constants';
 import { ConfigurationData } from '../../../src/data/ConfigurationData';
 import { CLIService } from '../../../src/services/CLIService';
@@ -230,6 +230,13 @@ describe('InitState tests', () => {
                         },
                         monitor: {
                             nodes: {}
+                        },
+                        web3: {
+                            opcode: {
+                                tracer: {
+                                    enabled: true
+                                }
+                            }
                         }
                     }
                 }
@@ -355,7 +362,19 @@ describe('InitState tests', () => {
             testSandbox.assert.called(fsReadFileSync);
             testSandbox.assert.called(fsWriteFileSync);
             testSandbox.assert.called(ymlLoad);
-            testSandbox.assert.called(ymlDump);
+            testSandbox.assert.calledWithMatch(ymlDump, {
+                hedera: {
+                    mirror: {
+                        web3 : {
+                            opcode: {
+                                tracer: {
+                                    enabled: true
+                                }
+                            }
+                        }
+                    }
+                }
+            });
 
             configureMirrorNodePropertiesStub = testSandbox.stub(initState as any, 'configureMirrorNodeProperties')
         })


### PR DESCRIPTION
**Problem**

As part of HIP-801, we need to change the mirror-node properties of the web3 module to enable the endpoint for the opcode logger which is disabled by default.

**Solution**

- We need to set the hedera.mirror.web3.opcode.tracer.enabled=true in the application.yml file with custom properties for the mirror-node.
- Change the docker configurations to override these values in the web3 module of mirror-node from the application.yml file
- Add documentation for the overridden properties of the web3 module in the local-node