### PR TITLE
chore: bump network images and release tag

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=main-network-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.51.3
-HAVEGED_IMAGE_TAG=0.51.3
+NETWORK_NODE_IMAGE_TAG=0.52.0-alpha.4
+HAVEGED_IMAGE_TAG=0.52.0-alpha.4
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m
@@ -29,7 +29,7 @@ PYTHON_VERSION=python3.7
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.108.0-beta1
+MIRROR_IMAGE_TAG=0.108.0
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=postgres:14-alpine
@@ -45,7 +45,7 @@ MINIO_ROOT_PASSWORD=minioadmin
 
 #### JSON RPC Relay Prefixes & Tags ####
 RELAY_IMAGE_PREFIX=ghcr.io/hashgraph/
-RELAY_IMAGE_TAG=0.50.1
+RELAY_IMAGE_TAG=0.51.1
 
 #### JSON RPC Relay limits ####
 RELAY_MEM_LIMIT=768m

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-local",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/sdk": "^2.48.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.51.3"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.51.3"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.108.0-beta1"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.50.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.52.0-alpha.4"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.52.0-alpha.4"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.108.0"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.51.1"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],
   "envConfiguration": [


### PR DESCRIPTION
**Description**:
This PR bumps all network tag to their latest versions, as well as the release tag to 2.27.1

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
