### PR TITLE
ci: update package.json and package-lock.json for semantic-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
         "chai": "^4.3.6",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
         "eslint": "^8.51.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^9.1.0",
@@ -3855,6 +3856,18 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
       "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
     "chai": "^4.3.6",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^8.51.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
**Description**:
Updating `package.json` and `package-lock.json` by running `npm i -D conventional-changelog-conventionalcommits`
This will allow commit-analyzer to use `conventional commits`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
