### PR TITLE
fix: local node not starting with tag command

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=consensus-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.53.0-alpha.2
+NETWORK_NODE_IMAGE_TAG=0.52.0
 HAVEGED_IMAGE_TAG=0.53.0-alpha.2
 
 #### Java Process Settings ####

--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=consensus-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.52.0
-HAVEGED_IMAGE_TAG=0.52.0-alpha.6
+NETWORK_NODE_IMAGE_TAG=0.53.0-alpha.2
+HAVEGED_IMAGE_TAG=0.53.0-alpha.2
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m
@@ -29,7 +29,7 @@ PYTHON_VERSION=python3.7
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.110.0-rc2
+MIRROR_IMAGE_TAG=0.111.0-rc1
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=ghcr.io/mhga24/postgres:latest
@@ -45,7 +45,7 @@ MINIO_ROOT_PASSWORD=minioadmin
 
 #### JSON RPC Relay Prefixes & Tags ####
 RELAY_IMAGE_PREFIX=ghcr.io/hashgraph/
-RELAY_IMAGE_TAG=0.52.1
+RELAY_IMAGE_TAG=0.53.0-rc4
 
 #### JSON RPC Relay limits ####
 RELAY_MEM_LIMIT=768m

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.28.1",
+  "version": "2.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-local",
-      "version": "2.28.1",
+      "version": "2.29.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hashgraph/sdk": "^2.48.1",
+        "@hashgraph/sdk": "^2.49.2",
         "blessed": "^0.1.81",
         "blessed-terminal": "^0.1.22",
         "csv-parser": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.28.1",
+  "version": "2.29.0",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {
@@ -64,7 +64,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@hashgraph/sdk": "^2.48.1",
+    "@hashgraph/sdk": "^2.49.2",
     "blessed": "^0.1.81",
     "blessed-terminal": "^0.1.22",
     "csv-parser": "^3.0.0",

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,6 +1,6 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.53.0-alpha.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.52.0"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.53.0-alpha.2"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.111.0-rc1"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.53.0-rc4"},

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.52.0"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.52.0-alpha.6"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.110.0-rc2"},
-    {"key": "RELAY_IMAGE_TAG", "value": "0.52.1"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.53.0-alpha.2"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.53.0-alpha.2"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.111.0-rc1"},
+    {"key": "RELAY_IMAGE_TAG", "value": "0.53.0-rc4"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],
   "envConfiguration": [

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -214,7 +214,7 @@ export class InitState implements IState{
     } {
         const node = variable.key;
         let tag = variable.value;
-        if (this.cliOptions.networkTag && (node === "NETWORK_NODE_IMAGE_TAG" || node === "HAVEGED_IMAGE_TAG")) {
+        if (this.cliOptions.networkTag && (node === "NETWORK_NODE_IMAGE_TAG")) {
             tag = this.cliOptions.networkTag;
         } else if(this.cliOptions.mirrorTag && node === "MIRROR_IMAGE_TAG") {
             tag = this.cliOptions.mirrorTag;

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -214,7 +214,9 @@ export class InitState implements IState{
     } {
         const node = variable.key;
         let tag = variable.value;
-        if (this.cliOptions.networkTag && (node === "NETWORK_NODE_IMAGE_TAG")) {
+        // ToDo: Revert this change, when docker hub issues are resolved
+        // if (this.cliOptions.networkTag && (node === "NETWORK_NODE_IMAGE_TAG" || node === "HAVEGED_IMAGE_TAG")) {
+        if (this.cliOptions.networkTag && node === "NETWORK_NODE_IMAGE_TAG") {
             tag = this.cliOptions.networkTag;
         } else if(this.cliOptions.mirrorTag && node === "MIRROR_IMAGE_TAG") {
             tag = this.cliOptions.mirrorTag;

--- a/test/cypress/package-lock.json
+++ b/test/cypress/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@hashgraph/sdk": "^2.49.2",
-        "cypress": "^13.13.1",
+        "cypress": "^13.13.2",
         "cypress-wait-until": "^3.0.2",
         "html-webpack-plugin": "^5.6.0",
         "http-server": "^14.1.1",
@@ -1761,13 +1761,13 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.1.tgz",
-      "integrity": "sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==",
+      "version": "13.13.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.2.tgz",
+      "integrity": "sha512-PvJQU33933NvS1StfzEb8/mu2kMy4dABwCF+yd5Bi7Qly1HOVf+Bufrygee/tlmty/6j5lX+KIi8j9Q3JUMbhA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -6092,12 +6092,12 @@
       "dev": true
     },
     "cypress": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.1.tgz",
-      "integrity": "sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==",
+      "version": "13.13.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.2.tgz",
+      "integrity": "sha512-PvJQU33933NvS1StfzEb8/mu2kMy4dABwCF+yd5Bi7Qly1HOVf+Bufrygee/tlmty/6j5lX+KIi8j9Q3JUMbhA==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "devDependencies": {
     "@hashgraph/sdk": "^2.49.2",
-    "cypress": "^13.13.1",
+    "cypress": "^13.13.2",
     "cypress-wait-until": "^3.0.2",
     "html-webpack-plugin": "^5.6.0",
     "http-server": "^14.1.1",


### PR DESCRIPTION
**Description**:
This PR fixes an issue where local-node throws an error on startup, if you try to load images using tag command. Problem comes from the recently changed docker hub policy and deployment of havaged images to the registry. 
Because this images is not actually used, we removed the ability to change the default value using the CLI.
Also bumped the images and local-node version

**Related issue(s)**:

Fixes #722 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
