### PR TITLE
fix: Intermittent failure on start of `AccountCreationState`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,10 @@ export const CONTAINERS = [
     },
 ];
 
+export const SDK_ERRORS = {
+    FAILED_TO_FIND_A_HEALTHY_NODE: "failed to find a healthy working node",
+}
+
 export const NETWORK_PREFIX = 'hedera-';
 
 export const CONSENSUS_NODE_LABEL = "network-node";
@@ -76,7 +80,7 @@ export const TRACE_COLOR = '\x1b[37m'
 // check success
 export const CHECK_SUCCESS = `${INFO_COLOR}[✔︎]${COLOR_RESET}`
 // check warn
-export const CHEKC_WARN = `${WARNING_COLOR}[!]${COLOR_RESET}`
+export const CHECK_WARN = `${WARNING_COLOR}[!]${COLOR_RESET}`
 // check fail
 export const CHECK_FAIL = `${ERROR_COLOR}[✘]${COLOR_RESET}`
 // waiting
@@ -135,7 +139,6 @@ export const ACCOUNT_CREATION_STARTING_SYNCHRONOUS_MESSAGE = `${LOADING} Startin
 export const ACCOUNT_CREATION_STARTING_ASYNCHRONOUS_MESSAGE = `${LOADING} Starting Account Creation state in asynchronous mode...`;
 export const ACCOUNT_CREATION_STARTING_ASYNCHRONOUS_BLOCKLIST_MESSAGE = `${LOADING} Starting Account Creation state in asynchronous mode with 1 blocklisted accounts...`;
 export const ACCOUNT_CREATION_FINISHED = `${CHECK_SUCCESS} Accounts created succefully!`;
-export const FAILED_TO_FIND_A_HEALTHY_NODE = "failed to find a healthy working node";
 
 // Resource Creation State
 export const RESOURCE_CREATION_STATE_INIT_MESSAGE = `${CHECK_SUCCESS} Resource Creation State Initialized!`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -135,6 +135,7 @@ export const ACCOUNT_CREATION_STARTING_SYNCHRONOUS_MESSAGE = `${LOADING} Startin
 export const ACCOUNT_CREATION_STARTING_ASYNCHRONOUS_MESSAGE = `${LOADING} Starting Account Creation state in asynchronous mode...`;
 export const ACCOUNT_CREATION_STARTING_ASYNCHRONOUS_BLOCKLIST_MESSAGE = `${LOADING} Starting Account Creation state in asynchronous mode with 1 blocklisted accounts...`;
 export const ACCOUNT_CREATION_FINISHED = `${CHECK_SUCCESS} Accounts created succefully!`;
+export const FAILED_TO_FIND_A_HEALTHY_NODE = "failed to find a healthy working node";
 
 // Resource Creation State
 export const RESOURCE_CREATION_STATE_INIT_MESSAGE = `${CHECK_SUCCESS} Resource Creation State Initialized!`;

--- a/src/services/LoggerService.ts
+++ b/src/services/LoggerService.ts
@@ -22,7 +22,7 @@ import { log, screen, Widgets } from 'blessed';
 import terminal from 'blessed-terminal';
 import {
     CHECK_FAIL,
-    CHEKC_WARN,
+    CHECK_WARN,
     COLOR_DIM,
     COLOR_RESET,
     CONSENSUS_NODE_LABEL,
@@ -33,7 +33,7 @@ import {
     MIRROR_NODE_LABEL,
     RELAY_LABEL,
     TRACE_COLOR,
-    WARNING_COLOR
+    WARNING_COLOR,
 } from '../constants';
 import { AccountCreationState } from '../state/AccountCreationState';
 import { VerboseLevel } from '../types/VerboseLevel';
@@ -233,7 +233,7 @@ export class LoggerService implements IService{
         if (this.verboseLevel < VerboseLevel.WARNING) {
             return;
         }
-        const msgToLog = LoggerService.messageCompute(`${CHEKC_WARN} ${msg}`, module, VerboseLevel.WARNING);
+        const msgToLog = LoggerService.messageCompute(`${CHECK_WARN} ${msg}`, module, VerboseLevel.WARNING);
         this.writeToLog(msgToLog, module);
     }
 

--- a/src/state/AccountCreationState.ts
+++ b/src/state/AccountCreationState.ts
@@ -33,9 +33,15 @@ import { ClientService } from '../services/ClientService';
 import {
     privateKeysAliasECDSA,
     privateKeysECDSA,
-    privateKeysED25519
+    privateKeysED25519,
 } from '../configuration/accountConfiguration.json';
-import { ACCOUNT_CREATION_STATE_INIT_MESSAGE, CHECK_SUCCESS, EVM_ADDRESSES_BLOCKLIST_FILE_RELATIVE_PATH, LOADING } from '../constants';
+import {
+    ACCOUNT_CREATION_STATE_INIT_MESSAGE,
+    CHECK_SUCCESS,
+    EVM_ADDRESSES_BLOCKLIST_FILE_RELATIVE_PATH,
+    FAILED_TO_FIND_A_HEALTHY_NODE,
+    LOADING,
+} from '../constants';
 import local from '../configuration/local.json';
 import { AccountUtils } from '../utils/AccountUtils';
 import { RetryUtils } from '../utils/RetryUtils';
@@ -271,6 +277,9 @@ export class AccountCreationState implements IState {
                         };
                     }),
                 {
+                    shouldRetry: (error) => {
+                        return error?.toString().includes(FAILED_TO_FIND_A_HEALTHY_NODE) ?? false;
+                    },
                     doOnRetry: (error) => this.logger.warn(
                         `Error occurred during task execution: "${error?.toString()}"`,
                         this.stateName
@@ -327,6 +336,9 @@ export class AccountCreationState implements IState {
                         };
                     }),
                 {
+                    shouldRetry: (error) => {
+                        return error?.toString().includes(FAILED_TO_FIND_A_HEALTHY_NODE) ?? false;
+                    },
                     doOnRetry: (error) => this.logger.warn(
                         `Error occurred during task execution: "${error?.toString()}"`,
                         this.stateName

--- a/src/state/AccountCreationState.ts
+++ b/src/state/AccountCreationState.ts
@@ -39,8 +39,8 @@ import {
     ACCOUNT_CREATION_STATE_INIT_MESSAGE,
     CHECK_SUCCESS,
     EVM_ADDRESSES_BLOCKLIST_FILE_RELATIVE_PATH,
-    FAILED_TO_FIND_A_HEALTHY_NODE,
     LOADING,
+    SDK_ERRORS,
 } from '../constants';
 import local from '../configuration/local.json';
 import { AccountUtils } from '../utils/AccountUtils';
@@ -495,7 +495,7 @@ export class AccountCreationState implements IState {
     }
 
     private shouldRetry = (error: unknown): boolean => {
-        return error?.toString().includes(FAILED_TO_FIND_A_HEALTHY_NODE) ?? false;
+        return error?.toString().includes(SDK_ERRORS.FAILED_TO_FIND_A_HEALTHY_NODE) ?? false;
     }
 
     private doOnRetry = (error: unknown): void => {

--- a/src/utils/RetryUtils.ts
+++ b/src/utils/RetryUtils.ts
@@ -1,0 +1,73 @@
+/*-
+ *
+ * Hedera Local Node
+ *
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export class RetryUtils {
+
+  /**
+   * Retries a task up to a specified number of times.
+   *
+   * @param {() => Promise<T>} task - The task to retry.
+   * @param {Object} options - The options for the retry.
+   * @param [options.maxAttempts=3] - The maximum number of attempts.
+   * @param [options.backOff=500] - The time to wait between attempts in milliseconds.
+   * @param [options.doOnRetry=(error, attempt) => {}] - The function to call on each retry.
+   * @returns {Promise<T>} - A promise that resolves with the result of the task.
+   * @template T
+   */
+  public static async retryTask<T>(
+    task: () => Promise<T>,
+    {
+      maxRetries = 3,
+      backOff = 500,
+      doOnRetry = (_error: unknown) => {},
+    }: {
+      maxRetries?: number;
+      backOff?: number;
+      doOnRetry?: (error: unknown) => void;
+    } = {}
+  ): Promise<T> {
+    let retries = 0;
+    while (retries < maxRetries) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        return await task();
+      } catch (error) {
+        if (retries === maxRetries - 1) {
+          throw error;
+        }
+        doOnRetry(error);
+        await this.delay(backOff);
+      }
+      retries += 1;
+    }
+    /* istanbul ignore next */
+    throw new Error('Unreachable code');
+  }
+
+  /**
+   * Delays the execution of the task.
+   * @param ms The time to wait in milliseconds.
+   * @returns {Promise<void>} A promise that resolves after the delay.
+   * @private
+   */
+  private static delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/src/utils/RetryUtils.ts
+++ b/src/utils/RetryUtils.ts
@@ -36,10 +36,12 @@ export class RetryUtils {
     {
       maxRetries = 3,
       backOff = 500,
+      shouldRetry = (_error: unknown) => true,
       doOnRetry = (_error: unknown) => {},
     }: {
       maxRetries?: number;
       backOff?: number;
+      shouldRetry?: (error: unknown) => boolean;
       doOnRetry?: (error: unknown) => void;
     } = {}
   ): Promise<T> {
@@ -49,7 +51,7 @@ export class RetryUtils {
         // eslint-disable-next-line no-await-in-loop
         return await task();
       } catch (error) {
-        if (retries === maxRetries - 1) {
+        if (!shouldRetry(error) || retries === maxRetries - 1) {
           throw error;
         }
         doOnRetry(error);

--- a/test/unit/states/AccountCreationState.spec.ts
+++ b/test/unit/states/AccountCreationState.spec.ts
@@ -29,7 +29,7 @@ import { SinonSandbox, SinonSpy, SinonStub, SinonStubbedInstance } from 'sinon';
 import {
   ACCOUNT_CREATION_STARTING_ASYNCHRONOUS_BLOCKLIST_MESSAGE,
   ACCOUNT_CREATION_STATE_INIT_MESSAGE,
-  FAILED_TO_FIND_A_HEALTHY_NODE,
+  SDK_ERRORS,
 } from '../../../src/constants';
 import { IOBserver } from '../../../src/controller/IObserver';
 import { AccountUtils } from '../../../src/utils/AccountUtils';
@@ -249,7 +249,7 @@ describe('AccountCreationState', () => {
       });
 
       it('should retry the creation of ECDSA accounts if there is an error', async () => {
-        const error = new Error(FAILED_TO_FIND_A_HEALTHY_NODE);
+        const error = new Error(SDK_ERRORS.FAILED_TO_FIND_A_HEALTHY_NODE);
         const errorCount = 2;
         rejectWithError(createAccountStub, error, errorCount);
 
@@ -324,7 +324,7 @@ describe('AccountCreationState', () => {
 
 
       it('should retry the creation of AliasECDSA accounts if there is an error', async () => {
-        const error = new Error(FAILED_TO_FIND_A_HEALTHY_NODE);
+        const error = new Error(SDK_ERRORS.FAILED_TO_FIND_A_HEALTHY_NODE);
         const errorCount = 2;
         rejectWithError(createAliasAccountStub, error, errorCount);
 
@@ -395,7 +395,7 @@ describe('AccountCreationState', () => {
       });
 
       it('should retry the creation of ED25519 accounts if there is an error', async () => {
-        const error = new Error(FAILED_TO_FIND_A_HEALTHY_NODE);
+        const error = new Error(SDK_ERRORS.FAILED_TO_FIND_A_HEALTHY_NODE);
         const errorCount = 2;
         rejectWithError(createAccountStub, error, errorCount);
 

--- a/test/unit/states/AccountCreationState.spec.ts
+++ b/test/unit/states/AccountCreationState.spec.ts
@@ -568,7 +568,7 @@ describe('AccountCreationState', () => {
       if (retries > 0) {
         testSandbox.assert.callCount(loggerService.warn, 2);
         for (const call of loggerService.warn.getCalls()) {
-          expect(call.args[0]).to.equal(`Error occurred during task execution: "${error.toString()}"`);
+          expect(call.args[0]).to.equal(`Error occurred during task execution: "${error!.toString()}"`);
         }
       } else {
         testSandbox.assert.notCalled(loggerService.warn);

--- a/test/unit/utils/RetryUtils.spec.ts
+++ b/test/unit/utils/RetryUtils.spec.ts
@@ -18,10 +18,10 @@
  *
  */
 
-import { createStubInstance, SinonSpy, SinonStubbedInstance, spy, stub } from "sinon";
-import { LoggerService } from "../../../src/services/LoggerService";
-import { RetryUtils } from "../../../src/utils/RetryUtils";
-import { expect } from "chai";
+import { createStubInstance, SinonSpy, SinonStubbedInstance, spy, stub } from 'sinon';
+import { LoggerService } from '../../../src/services/LoggerService';
+import { RetryUtils } from '../../../src/utils/RetryUtils';
+import { expect } from 'chai';
 
 describe('RetryUtils', () => {
   const backOff = 100;
@@ -94,5 +94,42 @@ describe('RetryUtils', () => {
     expect(task.callCount).to.equal(1);
     expect(doOnRetry.callCount).to.equal(0);
     expect(loggerService.error.callCount).to.equal(0);
+  });
+
+  it('should not retry if shouldRetry returns false', async () => {
+    const error = new Error('Non-retryable error');
+    const task = stub().rejects(error);
+    const shouldRetry = stub().returns(false);
+
+    try {
+      await RetryUtils.retryTask(task, { doOnRetry, backOff, shouldRetry });
+    } catch (e) {
+      expect(e).to.equal(error);
+    }
+
+    expect(task.callCount).to.equal(1);
+    expect(doOnRetry.callCount).to.equal(0);
+    expect(shouldRetry.callCount).to.equal(1);
+  });
+
+  it('should retry only for retryable errors', async () => {
+    const retryableError = new Error('Retryable error');
+    const nonRetryableError = new Error('Non-retryable error');
+    const task = stub()
+      .onFirstCall().rejects(retryableError)
+      .onSecondCall().rejects(nonRetryableError);
+    const shouldRetry = stub()
+      .onFirstCall().returns(true)
+      .onSecondCall().returns(false);
+
+    try {
+      await RetryUtils.retryTask(task, { doOnRetry, backOff, shouldRetry });
+    } catch (e) {
+      expect(e).to.equal(nonRetryableError);
+    }
+
+    expect(task.callCount).to.equal(2);
+    expect(doOnRetry.callCount).to.equal(1);
+    expect(shouldRetry.callCount).to.equal(2);
   });
 });

--- a/test/unit/utils/RetryUtils.spec.ts
+++ b/test/unit/utils/RetryUtils.spec.ts
@@ -1,0 +1,98 @@
+/*-
+ *
+ * Hedera Local Node
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { createStubInstance, SinonSpy, SinonStubbedInstance, spy, stub } from "sinon";
+import { LoggerService } from "../../../src/services/LoggerService";
+import { RetryUtils } from "../../../src/utils/RetryUtils";
+import { expect } from "chai";
+
+describe('RetryUtils', () => {
+  const backOff = 100;
+  let doOnRetry: SinonSpy;
+  let loggerService: SinonStubbedInstance<LoggerService>;
+
+  beforeEach(() => {
+    doOnRetry = spy((e) => loggerService.error(e.message));
+    loggerService = createStubInstance(LoggerService);
+  });
+
+  afterEach(() => {
+    doOnRetry.resetHistory();
+  });
+
+  it('should retry the task until it succeeds', async () => {
+    const error = new Error('First attempt failed');
+    const task = stub()
+      .onFirstCall().rejects(error)
+      .onSecondCall().resolves('Success');
+
+    const result = await RetryUtils.retryTask(task, { doOnRetry, backOff });
+
+    expect(result).to.equal('Success');
+    expect(task.callCount).to.equal(2);
+    expect(doOnRetry.callCount).to.equal(1);
+    expect(loggerService.error.callCount).to.equal(1);
+    expect(loggerService.error.getCall(0).args[0]).to.equal(error.message);
+  });
+
+  it('should throw an error after max retries', async () => {
+    const error = new Error('Task failed');
+    const task = stub().rejects(error);
+
+    try {
+      await RetryUtils.retryTask(task, { doOnRetry, backOff, maxRetries: 5 });
+    } catch (e) {
+      expect(e).to.equal(error);
+    }
+
+    expect(task.callCount).to.equal(5);
+    expect(doOnRetry.callCount).to.equal(4);
+  });
+
+  it('should log an error message on each failure', async () => {
+    const error = new Error('Task failed');
+    const task = stub().rejects(error);
+
+    try {
+      await RetryUtils.retryTask(task, { doOnRetry, backOff });
+    } catch (e) {
+      expect(e).to.equal(error);
+    }
+
+    expect(task.callCount).to.equal(3);
+    expect(doOnRetry.callCount).to.equal(2);
+    expect(loggerService.error.callCount).to.equal(2);
+    for (let i = 0; i < 2; i++) {
+      expect(doOnRetry.getCall(i).args[0]).to.equal(error);
+      expect(loggerService.error.getCall(i).args[0]).to.equal(error.message);
+    }
+  });
+
+  it('should succeed on the first attempt without retries', async () => {
+    const task = stub().resolves('Success');
+
+    const result = await RetryUtils.retryTask(task, { doOnRetry, backOff });
+
+    expect(result).to.equal('Success');
+    expect(task.callCount).to.equal(1);
+    expect(doOnRetry.callCount).to.equal(0);
+    expect(loggerService.error.callCount).to.equal(0);
+  });
+});


### PR DESCRIPTION
**Description**:

If the AccountCreationState begins, but the SDK is not yet connected to a healthy node, the local node would throw this error when starting up. We need to implement some sort of retry mechanism in case this issue happens.

This PR implements a retry mechanism to handle the scenario where the SDK is not connected to a healthy node at the start of the `AccountCreationState`. The retry mechanism will attempt to reconnect to a healthy node a specified number of times before failing.

**Changes:**
1. **Retry Mechanism:**
   - Added a new class `RetryUtils.ts` with a `retryTask` function to handle retry logic.
   - Configured the retry mechanism to execute the given task a specified number of times with a delay between attempts.

2. **Integration with `AccountCreationState`:**
   - Integrated the retry mechanism into the `AccountCreationState` to ensure it retries each call to the SDK for account creations

**Related issue(s)**:

Fixes #733

**Notes for reviewer**:

- The retry mechanism parameters (number of retries and delay) can be configured as needed.
- This change improves the robustness of the startup process by handling transient connection issues gracefully.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
  - [x] Added unit tests in `RetryUtils.spec.ts` to verify the retry logic.
  - [x] Updated `AccountCreationState.spec.ts` to test the retry mechanism integration.