### PR TITLE
ci: update workflows to use latitude.sh based runners

### DIFF
--- a/.github/workflows/flow-pr-title-check.yaml
+++ b/.github/workflows/flow-pr-title-check.yaml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   title-check:
     name: Title Check
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: local-node-linux-medium
     steps:
       - name: Check PR Title
         uses: step-security/conventional-pr-title-action@0eae74515f5a79f8773fa04142dd746df76666ac # v1.0.0

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   smoke-tests:
     name: Smoke Tests
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: local-node-linux-medium
 
     strategy:
       fail-fast: false
@@ -78,7 +78,7 @@ jobs:
 
   browser-tests:
     name: Browser Tests
-    runs-on: [self-hosted, Linux, large, ephemeral ]
+    runs-on: local-node-linux-large
 
     strategy:
       fail-fast: false
@@ -118,7 +118,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: local-node-linux-medium
 
     strategy:
       fail-fast: false

--- a/.github/workflows/flow-semantic-release.yml
+++ b/.github/workflows/flow-semantic-release.yml
@@ -9,7 +9,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: local-node-linux-medium
     steps:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/publish-npm-package.yaml
+++ b/.github/workflows/publish-npm-package.yaml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   publish-npm-package:
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: local-node-linux-medium
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the CI workflows `runs-on` labels to use the new Latitude.sh based runners.

### Related Issues

- Closes #755 