### PR TITLE
chore: bump tags of network node and mirror node

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=consensus-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.53.2
-HAVEGED_IMAGE_TAG=0.53.2
+NETWORK_NODE_IMAGE_TAG=0.54.0-alpha.2
+HAVEGED_IMAGE_TAG=0.54.0-alpha.2
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m

--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ PYTHON_VERSION=python3.7
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.111.0-rc1
+MIRROR_IMAGE_TAG=0.112.1
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=ghcr.io/mhga24/postgres:latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.29.3",
+  "version": "2.29.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-local",
-      "version": "2.29.3",
+      "version": "2.29.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/sdk": "^2.49.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.29.3",
+  "version": "2.29.4",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -2,7 +2,7 @@
   "imageTagConfiguration": [
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.54.0-alpha.2"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.54.0-alpha.2"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.111.0-rc1"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.112.1"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.54.4"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,7 +1,7 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.53.2"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.53.2"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.54.0-alpha.2"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.54.0-alpha.2"},
     {"key": "MIRROR_IMAGE_TAG", "value": "0.111.0-rc1"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.54.4"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}


### PR DESCRIPTION
**Description**:

This PR bumps:
- network-tag to `0.54.0-alpha.2`
- mirror-tag to `0.112.1`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
