### PR TITLE
feat: Add Hedera Mirror Node Rest Java container

### DIFF
--- a/compose-network/mirror-node/application.yml
+++ b/compose-network/mirror-node/application.yml
@@ -1,5 +1,26 @@
 hedera:
   mirror:
+    restJava:
+      db:
+        host: 127.0.0.1
+        name: mirror_node
+        password: mirror_rest_java_pass
+        port: 5432
+        sslMode: DISABLE
+        statementTimeout: 10000
+        username: mirror_rest_java
+      response:
+        headers:
+          defaults:
+            # Headers set by default unless overridden in specific request mapping paths defined below.
+            "Access-Control-Allow-Origin": "*"
+            "Cache-Control": "public, max-age=1"
+          path:
+            # Override inherited defaults and define additional headers for individual controller request mappings.
+            # "[]" around the path preserves special characters. Multiple header name/value pairs may be defined per path.
+            "[/api/v1/topics/{id}]":
+              "Cache-Control": "public, max-age=5"
+
     grpc:
       listener:
         type: SHARED_POLL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,6 +279,29 @@ services:
     restart: unless-stopped
     tty: false
 
+  rest-java:
+    image: "${MIRROR_IMAGE_PREFIX}hedera-mirror-rest-java:${MIRROR_REST_IMAGE_TAG:-${MIRROR_IMAGE_TAG}}"
+    container_name: mirror-node-rest-java
+    mem_swappiness: 0
+    mem_limit: "${MIRROR_REST_MEM_LIMIT}"
+    memswap_limit: "${MIRROR_REST_MEM_LIMIT}"
+    depends_on:
+      importer:
+        condition: service_started
+      db:
+        condition: service_started
+    environment:
+      HEDERA_MIRROR_RESTJAVA_DB_HOST: db
+      SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-rest-java/
+    networks:
+      - mirror-node
+    ports:
+      - 8084:8084
+    restart: unless-stopped
+    tty: true
+    volumes:
+      - ./application.yml:/usr/etc/hedera-mirror-rest-java/application.yml
+
   explorer:
     container_name: hedera-explorer
     image: "${MIRROR_NODE_EXPLORER_IMAGE_PREFIX}hedera-mirror-node-explorer:${MIRROR_NODE_EXPLORER_IMAGE_TAG}"


### PR DESCRIPTION
**Description**:
This PR aims to add the new mirror node java rest module as a docker container, with the following changes:

- Setups up the docker-compose file to include this new container.
- Setup application.yml to include the needed variables for the rest-java module.

**Related issue(s)**:

Fixes #790 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
