### PR TITLE
fix: Add contracts.maxRefundPercentOfGasLimit=100.

### DIFF
--- a/compose-network/network-node/data/config/application.properties
+++ b/compose-network/network-node/data/config/application.properties
@@ -4,3 +4,4 @@ netty.mode=DEV
 contracts.chainId=298
 hedera.recordStream.logPeriod=1
 balances.exportPeriodSecs=400
+contracts.maxRefundPercentOfGasLimit=100


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR modifies the `compose-network/network-node/data/config/application.properties` file to add `contracts.maxRefundPercentOfGasLimit=100` in order to allow the devs to be able to see the actual gas used.

**Related issue(s)**:

Fixes #408 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
While the proposed fix mentioned edits the file `compose-network/network-node/application.properties`, I realized it had been moved to `compose-network/network-node/data/config/application.properties` in the commit with hash 6de4da67bde882f845267855cdaa26ed65b3343a. So I edited the new file instead.