### PR TITLE
feat: deprecate sunrise tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npm install && npm install -g
 `npm run stop` to stop the network
 `npm run generate-accounts` to generate new account for already started network
 
-> **_NOTE:_**  If you want to use any of the CLI options listed below, you'd need to pass `--` after `npm run start` (for example) and then specify the wanted option. For example, if you want to start in detached mode, you can use `npm run start -- -d`
+> **_NOTE:_**  If you want to use any of the CLI options listed below, you'd need to pass `--` after `npm run start` (for example) and then specify the wanted option.
 
 > **_WARNING:_** While stopping the networks, we will first list all Docker networks with the `hedera-` prefix in their names. This operation may affect not only the networks initiated by the `npm run start` command from this repository but also any other networks you have created with this prefix. Network termination can be triggered both by a direct `npm run stop` call and by the `npm run start` script if the initial startup process fails and failover recovery is activated. One of the recovery steps includes attempting to close all previously started networks with the `hedera-` prefix.
 
@@ -105,7 +105,6 @@ Local Hedera Package - Runs consensus and mirror nodes on localhost:
 Available commands:
     start - Starts the local hedera network.
         options:
-            --d or --detached for starting in detached mode.
             --verbose set the verbose level. Defaults to 'info' choices are "info" & "trace"
             --h or --host to override the default host.
             --l or --limits to enable/disable the JSON-RPC relay rate limits. Defaults to true.
@@ -165,7 +164,7 @@ $ hedera start
 [Hedera-Local-Node] INFO (InitState) Setting configuration for local network with latest images on host 127.0.0.1 with dev mode turned off using turbo mode in single node configuration...
 [Hedera-Local-Node] INFO (InitState) Hedera JSON-RPC Relay rate limits were disabled.
 [Hedera-Local-Node] INFO (InitState) Needed environment variables were set for this configuration.
-[Hedera-Local-Node] INFO (InitState) Needed bootsrap properties were set for this configuration.
+[Hedera-Local-Node] INFO (InitState) Needed bootstrap properties were set for this configuration.
 [Hedera-Local-Node] INFO (InitState) Needed mirror node properties were set for this configuration.
 [Hedera-Local-Node] INFO (StartState) Starting Hedera Local Node...
 [Hedera-Local-Node] INFO (StartState) Detecting network...
@@ -231,7 +230,6 @@ $ hedera start
 - --accounts - Default is 10 per type. Specify the number of accounts to generate at startup. The first 10 are with predefined
   private keys, and the next ones are with random generated private keys.
 
-- --d / --detached - Start the local node in detached mode.
 - --h / --host - Override the default host.
 
 ```bash
@@ -241,7 +239,7 @@ $ hedera start --accounts=2
 [Hedera-Local-Node] INFO (InitState) Setting configuration for local network with latest images on host 127.0.0.1 with dev mode turned off using turbo mode in single node configuration...
 [Hedera-Local-Node] INFO (InitState) Hedera JSON-RPC Relay rate limits were disabled.
 [Hedera-Local-Node] INFO (InitState) Needed environment variables were set for this configuration.
-[Hedera-Local-Node] INFO (InitState) Needed bootsrap properties were set for this configuration.
+[Hedera-Local-Node] INFO (InitState) Needed bootstrap properties were set for this configuration.
 [Hedera-Local-Node] INFO (InitState) Needed mirror node properties were set for this configuration.
 [Hedera-Local-Node] INFO (StartState) Starting Hedera Local Node...
 [Hedera-Local-Node] INFO (StartState) Detecting network...
@@ -307,7 +305,7 @@ $ hedera restart
 [Hedera-Local-Node] INFO (InitState) Setting configuration for local network with latest images on host 127.0.0.1 with dev mode turned off using turbo mode in single node configuration...
 [Hedera-Local-Node] INFO (InitState) Hedera JSON-RPC Relay rate limits were disabled.
 [Hedera-Local-Node] INFO (InitState) Needed environment variables were set for this configuration.
-[Hedera-Local-Node] INFO (InitState) Needed bootsrap properties were set for this configuration.
+[Hedera-Local-Node] INFO (InitState) Needed bootstrap properties were set for this configuration.
 [Hedera-Local-Node] INFO (InitState) Needed mirror node properties were set for this configuration.
 [Hedera-Local-Node] INFO (StartState) Starting Hedera Local Node...
 [Hedera-Local-Node] INFO (StartState) Detecting network...
@@ -372,7 +370,6 @@ $ hedera restart
 - --accounts - Default is 10. Specify the number of accounts to generate at startup. The first 10 are with predefined
   private keys, and the next ones are with random generated private keys.
 
-- --d / --detached - Start the local node in detached mode.
 - --h / --host - Override the default host.
 
 ```bash
@@ -385,7 +382,7 @@ $ hedera restart --accounts=2
 [Hedera-Local-Node] INFO (InitState) Setting configuration for local network with latest images on host 127.0.0.1 with dev mode turned off using turbo mode in single node configuration...
 [Hedera-Local-Node] INFO (InitState) Hedera JSON-RPC Relay rate limits were disabled.
 [Hedera-Local-Node] INFO (InitState) Needed environment variables were set for this configuration.
-[Hedera-Local-Node] INFO (InitState) Needed bootsrap properties were set for this configuration.
+[Hedera-Local-Node] INFO (InitState) Needed bootstrap properties were set for this configuration.
 [Hedera-Local-Node] INFO (InitState) Needed mirror node properties were set for this configuration.
 [Hedera-Local-Node] INFO (StartState) Starting Hedera Local Node...
 [Hedera-Local-Node] INFO (StartState) Detecting network...

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/sdk": "^2.49.2",
-        "blessed": "^0.1.81",
-        "blessed-terminal": "^0.1.22",
         "csv-parser": "^3.0.0",
         "detect-port": "^1.6.1",
         "dockerode": "^4.0.2",
@@ -32,7 +30,6 @@
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/release-notes-generator": "^14.0.1",
-        "@types/blessed": "^0.1.25",
         "@types/chai": "^4.3.16",
         "@types/detect-port": "^1.3.5",
         "@types/dockerode": "^3.3.29",
@@ -533,6 +530,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
@@ -2288,15 +2286,6 @@
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
     },
-    "node_modules/@types/blessed": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@types/blessed/-/blessed-0.1.25.tgz",
-      "integrity": "sha512-kQsjBgtsbJLmG6CJA+Z6Nujj+tq1fcSE3UIowbDvzQI4wWmoTV7djUDhSo5lDjgwpIN0oRvks0SA5mMdKE5eFg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "4.3.16",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
@@ -2691,11 +2680,6 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2790,31 +2774,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
-      "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
-      "dependencies": {
-        "type-fest": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2836,19 +2795,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/ansi-term": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ansi-term/-/ansi-term-0.0.2.tgz",
-      "integrity": "sha512-jLnGE+n8uAjksTJxiWZf/kcUmXq+cRWSl550B9NmQ8YiqaTM+lILcSe5dHdp8QkJPhaOghDjnMKwyYSMjosgAA==",
-      "dependencies": {
-        "x256": ">=0.0.1"
-      }
-    },
-    "node_modules/ansicolors": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -3256,101 +3202,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/blessed": {
-      "version": "0.1.81",
-      "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
-      "integrity": "sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ==",
-      "bin": {
-        "blessed": "bin/tput.js"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/blessed-terminal": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/blessed-terminal/-/blessed-terminal-0.1.22.tgz",
-      "integrity": "sha512-R8Ej+yzsaey7gW5DSmPhIC28gNLYQad6lMODuEw0X4KzudWWxZQ632Z+BRJk2EHN5dsFWRWhvLbD+M5Vs5J+AA==",
-      "dependencies": {
-        "ansi-term": ">=0.0.2",
-        "chalk": "^2.4.2",
-        "drawille-canvas-blessed-contrib": ">=0.1.3",
-        "lodash": "~>=4.17.21",
-        "map-canvas": ">=0.1.5",
-        "marked": "^4.0.12",
-        "marked-terminal": "^5.1.1",
-        "memory-streams": "^0.1.0",
-        "memorystream": "^0.3.1",
-        "picture-tuber": "^1.0.1",
-        "sparkline": "^0.1.1",
-        "term-canvas": "0.0.5",
-        "x256": ">=0.0.1"
-      }
-    },
-    "node_modules/blessed-terminal/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/blessed-terminal/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/blessed-terminal/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/blessed-terminal/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/blessed-terminal/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/blessed-terminal/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/blessed-terminal/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -3381,11 +3232,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/bresenham": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/bresenham/-/bresenham-0.0.3.tgz",
-      "integrity": "sha512-wbMxoJJM1p3+6G7xEFXYNCJ30h2qkwmVxebkbwIl4OcnWtno5R3UT9VuYLfStlVNAQCmRjkGwjPFdfaPd4iNXw=="
     },
     "node_modules/brorand": {
       "version": "1.1.0",
@@ -3456,14 +3302,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "engines": {
-        "node": ">=0.2.0"
-      }
     },
     "node_modules/buildcheck": {
       "version": "0.0.6",
@@ -3548,18 +3386,6 @@
         }
       ]
     },
-    "node_modules/cardinal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
-      "dependencies": {
-        "ansicolors": "~0.3.2",
-        "redeyed": "~2.1.0"
-      },
-      "bin": {
-        "cdl": "bin/cdl.js"
-      }
-    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -3610,11 +3436,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/charm": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
-      "integrity": "sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ=="
     },
     "node_modules/check-error": {
       "version": "1.0.3",
@@ -3757,6 +3578,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
       "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -3937,7 +3759,8 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -4352,23 +4175,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/drawille-blessed-contrib": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/drawille-blessed-contrib/-/drawille-blessed-contrib-1.0.0.tgz",
-      "integrity": "sha512-WnHMgf5en/hVOsFhxLI8ZX0qTJmerOsVjIMQmn4cR1eI8nLGu+L7w5ENbul+lZ6w827A3JakCuernES5xbHLzQ=="
-    },
-    "node_modules/drawille-canvas-blessed-contrib": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/drawille-canvas-blessed-contrib/-/drawille-canvas-blessed-contrib-0.1.3.tgz",
-      "integrity": "sha512-bdDvVJOxlrEoPLifGDPaxIzFh3cD7QH05ePoQ4fwnqfi08ZSxzEhOUpI5Z0/SQMlWgcCQOEtuw0zrwezacXglw==",
-      "dependencies": {
-        "ansi-term": ">=0.0.2",
-        "bresenham": "0.0.3",
-        "drawille-blessed-contrib": ">=0.0.1",
-        "gl-matrix": "^2.1.0",
-        "x256": ">=0.0.1"
       }
     },
     "node_modules/duplexer2": {
@@ -5260,6 +5066,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -5346,28 +5153,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/event-stream": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.9.8.tgz",
-      "integrity": "sha512-o5h0Mp1bkoR6B0i7pTCAzRy+VzdsRWH997KQD4Psb0EOPoKEIiaRx/EsOdUl7p1Ktjw7aIWvweI/OY1R9XrlUg==",
-      "dependencies": {
-        "optimist": "0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/event-stream/node_modules/optimist": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
-      "integrity": "sha512-Wy7E3cQDpqsTIFyW7m22hSevyTLxw850ahYv7FWsw4G6MIKVTZ8NSA95KBrQ95a4SMsMr1UGUUnwEFKhVaSzIg==",
-      "dependencies": {
-        "wordwrap": ">=0.0.1 <0.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -5980,11 +5765,6 @@
         "through2": "~2.0.0"
       }
     },
-    "node_modules/gl-matrix": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.8.1.tgz",
-      "integrity": "sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw=="
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6285,11 +6065,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/here": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/here/-/here-0.0.2.tgz",
-      "integrity": "sha512-U7VYImCTcPoY27TSmzoiFsmWLEqQFaYNdpsPb9K0dXJhE6kufUqycaz51oR09CW85dDU9iWyy7At8M+p7hb3NQ=="
     },
     "node_modules/highlight.js": {
       "version": "10.7.3",
@@ -7443,7 +7218,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -7583,93 +7359,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
-    "node_modules/map-canvas": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/map-canvas/-/map-canvas-0.1.5.tgz",
-      "integrity": "sha512-f7M3sOuL9+up0NCOZbb1rQpWDLZwR/ftCiNbyscjl9LUUEwrRaoumH4sz6swgs58lF21DQ0hsYOCw5C6Zz7hbg==",
-      "dependencies": {
-        "drawille-canvas-blessed-contrib": ">=0.0.1",
-        "xml2js": "^0.4.5"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/marked-terminal": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.2.0.tgz",
-      "integrity": "sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==",
-      "dependencies": {
-        "ansi-escapes": "^6.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^5.2.0",
-        "cli-table3": "^0.6.3",
-        "node-emoji": "^1.11.0",
-        "supports-hyperlinks": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/marked-terminal/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/memory-streams": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
-      "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
-      "dependencies": {
-        "readable-stream": "~1.0.2"
-      }
-    },
-    "node_modules/memory-streams/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
-    "node_modules/memory-streams/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/memory-streams/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
-    },
-    "node_modules/memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
-      "engines": {
-        "node": ">= 0.10.0"
-      }
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -7994,14 +7683,6 @@
         "path-to-regexp": "^8.1.0"
       }
     },
-    "node_modules/node-emoji": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -8027,17 +7708,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
-    },
-    "node_modules/nopt": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-      "integrity": "sha512-x8vXm7BZ2jE1Txrxh/hO74HTuYZQEbo8edoRcANgdZ4+PCV+pbjd/xdummkmjjC7LU5EjPzlu8zEq/oxWylnKA==",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
     },
     "node_modules/normalize-package-data": {
       "version": "6.0.2",
@@ -11062,14 +10732,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -11372,25 +11034,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/picture-tuber": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/picture-tuber/-/picture-tuber-1.0.2.tgz",
-      "integrity": "sha512-49/xq+wzbwDeI32aPvwQJldM8pr7dKDRuR76IjztrkmiCkAQDaWFJzkmfVqCHmt/iFoPFhHmI9L0oKhthrTOQw==",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "charm": "~0.1.0",
-        "event-stream": "~0.9.8",
-        "optimist": "~0.3.4",
-        "png-js": "~0.1.0",
-        "x256": "~0.0.1"
-      },
-      "bin": {
-        "picture-tube": "bin/tube.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -11602,11 +11245,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/png-js": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/png-js/-/png-js-0.1.1.tgz",
-      "integrity": "sha512-NTtk2SyfjBm+xYl2/VZJBhFnTQ4kU5qWC7VC4/iGbrgiU4FuB4xC+74erxADYJIqZICOR1HCvRA7EBHkpjTg9g=="
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -12002,14 +11640,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/redeyed": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
-      "dependencies": {
-        "esprima": "~4.0.0"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -12285,11 +11915,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
@@ -12974,21 +12599,6 @@
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
     },
-    "node_modules/sparkline": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/sparkline/-/sparkline-0.1.2.tgz",
-      "integrity": "sha512-t//aVOiWt9fi/e22ea1vXVWBDX+gp18y+Ch9sKqmHl828bRfvP2VtfTJVEcgWFBQHd0yDPNQRiHdqzCvbcYSDA==",
-      "dependencies": {
-        "here": "0.0.2",
-        "nopt": "~2.1.2"
-      },
-      "bin": {
-        "sparkline": "bin/sparkline"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/spawn-error-forwarder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -13369,18 +12979,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -13497,11 +13095,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/term-canvas": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/term-canvas/-/term-canvas-0.0.5.tgz",
-      "integrity": "sha512-eZ3rIWi5yLnKiUcsW8P79fKyooaLmyLWAGqBhFspqMxRNUiB4GmHHk5AzQ4LxvFbJILaXqQZLwbbATLOhCFwkw=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -14132,14 +13725,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/workerpool": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
@@ -14213,34 +13798,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/x256": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/x256/-/x256-0.0.2.tgz",
-      "integrity": "sha512-ZsIH+sheoF8YG9YG+QKEEIdtqpHRA9FYuD7MqhfyB1kayXU43RUNBFSxBEnF8ywSUxdg+8no4+bPr5qLbyxKgA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {
-    "test:readiness": "node --loader ts-node/esm src/utils/testNode.js",
     "build": "rimraf ./build && tsc",
     "start": "npm run build && node ./build/index.js start",
     "restart": "npm run build && node ./build/index.js restart",
@@ -36,7 +35,6 @@
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/release-notes-generator": "^14.0.1",
-    "@types/blessed": "^0.1.25",
     "@types/chai": "^4.3.16",
     "@types/detect-port": "^1.3.5",
     "@types/dockerode": "^3.3.29",
@@ -65,8 +63,6 @@
   },
   "dependencies": {
     "@hashgraph/sdk": "^2.49.2",
-    "blessed": "^0.1.81",
-    "blessed-terminal": "^0.1.22",
     "csv-parser": "^3.0.0",
     "detect-port": "^1.6.1",
     "dockerode": "^4.0.2",

--- a/src/services/CLIService.ts
+++ b/src/services/CLIService.ts
@@ -75,7 +75,6 @@ export class CLIService implements IService{
     public static loadStartupOptions(yargs: Argv<{}>): void {
         CLIService.loadCommonOptions(yargs)
         CLIService.loadAccountOptions(yargs, true);
-        CLIService.detachedOption(yargs);
         CLIService.hostOption(yargs);
         CLIService.rateLimitOption(yargs);
         CLIService.devModeOption(yargs);
@@ -140,7 +139,6 @@ export class CLIService implements IService{
         const accounts = argv.accounts as number;
         const async = argv.async as boolean;
         const balance = argv.balance as number;
-        const detached = argv.detached as boolean;
         const host = argv.host as string;
         const limits = argv.limits as boolean;
         const devMode = argv.dev as boolean;
@@ -163,7 +161,6 @@ export class CLIService implements IService{
             accounts,
             async,
             balance,
-            detached,
             host,
             limits,
             devMode,
@@ -196,7 +193,6 @@ export class CLIService implements IService{
         const state = argv._[0] as string
         this.currentArgv = {
             ...argv,
-            detached: CLIService.isStartup(state) ? argv.detached : true,
             startup: CLIService.isStartup(state)
         };
     }
@@ -237,26 +233,6 @@ export class CLIService implements IService{
         yargs.positional('accounts', {
             describe: 'Generated accounts of each type.',
             default: 10
-        });
-    }
-
-    /**
-     * Adds the 'detached' option to the command line arguments.
-     * This option is a boolean that specifies whether to run the local node in detached mode.
-     * It is not required and defaults to false.
-     * The option can also be set using the alias 'd'.
-     * 
-     * @param {yargs.Argv<{}>} yargs - The yargs instance to which the option is added.
-     * @private
-     * @static
-     */
-    private static detachedOption(yargs: Argv<{}>): void {
-        yargs.option('detached', {
-            alias: 'd',
-            type: 'boolean',
-            describe: 'Run the local node in detached mode',
-            demandOption: false,
-            default: false
         });
     }
 

--- a/src/services/LoggerService.ts
+++ b/src/services/LoggerService.ts
@@ -18,46 +18,23 @@
  *
  */
 
-import { log, screen, Widgets } from 'blessed';
-import terminal from 'blessed-terminal';
 import {
     CHECK_FAIL,
     CHECK_WARN,
     COLOR_DIM,
     COLOR_RESET,
-    CONSENSUS_NODE_LABEL,
-    CONTAINERS,
     DEBUG_COLOR,
     ERROR_COLOR,
     INFO_COLOR,
-    MIRROR_NODE_LABEL,
-    RELAY_LABEL,
     TRACE_COLOR,
     WARNING_COLOR,
 } from '../constants';
-import { AccountCreationState } from '../state/AccountCreationState';
 import { VerboseLevel } from '../types/VerboseLevel';
-import { CLIService } from './CLIService';
-import { ConnectionService } from './ConnectionService';
-import { DockerService } from './DockerService';
 import { IService } from './IService';
-import { ServiceLocator } from './ServiceLocator';
-import { ResourceCreationState } from '../state/ResourceCreationState';
-
-
-export enum LogBoard {
-    CONSENSUS = 'CONSENSUS',
-    MIRROR = 'MIRROR',
-    RELAY = 'RELAY',
-    ACCOUNT = 'ACCOUNT',
-    RESOURCE = 'RESOURCE',
-}
 
 /**
  * LoggerService is a service class that handles logging.
  * It implements the IService interface.
- * It uses the 'blessed' and 'blessed-terminal' modules to create a terminal user interface for logging.
- * It also uses the 'console' object for logging when the terminal user interface is not used.
  * @public
  */
 export class LoggerService implements IService{
@@ -66,7 +43,7 @@ export class LoggerService implements IService{
      * @private
      */
     private readonly logger: Console;
-    
+
     /**
      * The name of the service.
      * @private
@@ -74,65 +51,10 @@ export class LoggerService implements IService{
     private readonly serviceName: string;
 
     /**
-     * The screen used by the LoggerService.
-     * @private
-     */
-    private screen: Widgets.Screen | undefined;
-
-    /**
-     * The grid used by the LoggerService.
-     * @private
-     */
-    private grid: terminal.grid | undefined;
-
-    /**
-     * The status table element used by the LoggerService.
-     * @private
-     */
-    private status: terminal.Widgets.TableElement | undefined;
-
-    /**
-     * The consensus log element used by the LoggerService.
-     * @private
-     */
-    private consensusLog: terminal.Widgets.LogElement | undefined;
-
-    /**
-     * The mirror log element used by the LoggerService.
-     * @private
-     */
-    private mirrorLog: terminal.Widgets.LogElement | undefined;
-
-    /**
-     * The relay log element used by the LoggerService.
-     * @private
-     */
-    private relayLog: terminal.Widgets.LogElement | undefined;
-
-    /**
-     * The account board log element used by the LoggerService.
-     * @private
-     */
-    private accountBoard: terminal.Widgets.LogElement | undefined;
-
-    /**
-     * The resource board log element used by the LoggerService.
-     * @private
-     */
-    private resourceBoard: terminal.Widgets.LogElement | undefined;
-
-    /**
-     * The info board table element used by the LoggerService.
-     * @private
-     */
-    private infoBoard: terminal.Widgets.TableElement | undefined;
-
-    /**
      * The verbosity level of the LoggerService.
      * @private
      */
     private readonly verboseLevel: number;
-
 
     /**
      * Creates an instance of the LoggerService.
@@ -166,21 +88,6 @@ export class LoggerService implements IService{
             default:
                 return INFO_COLOR;
         }
-    }
-
-    /**
-     * Get the log board based on the given module (service class name).
-     * @param module - The module where the message originates.
-     * @returns The {@link LogBoard} where the message should be printed.
-     */
-    private static getLogLocation(module: string): LogBoard {
-        if (module === AccountCreationState.name) {
-            return LogBoard.ACCOUNT;
-        }
-        if (module === ResourceCreationState.name) {
-            return LogBoard.RESOURCE;
-        }
-        return LogBoard.CONSENSUS;
     }
 
     /**
@@ -266,381 +173,11 @@ export class LoggerService implements IService{
     }
 
     /**
-     * Attaches a terminal user interface to the logger.
-     * @param msg - The message to log.
-     * @param containerLabel - The container label.
-     * @public
-     */
-    public attachTUI(msg: string, containerLabel: string): void {
-        switch (containerLabel) {
-            case CONSENSUS_NODE_LABEL:
-                this.consensusLog?.log(msg);
-                break;
-            case RELAY_LABEL:
-                this.relayLog?.log(msg);
-                break;
-            case MIRROR_NODE_LABEL:
-                this.mirrorLog?.log(msg);
-                break;
-            default:
-                this.consensusLog?.log(msg);
-                break;
-        }
-    }
-
-    /**
      * Writes a message to the log.
      * @param msg - The message to write.
      * @param module - The module where the message originates.
      */
     private writeToLog(msg: string, module: string): void {
-        const detached = this.isDetachedMode();
-        if (detached) {
-            this.logger.log(msg);
-        } else {
-            const logBoard = LoggerService.getLogLocation(module);
-            this.logToTUI(msg, logBoard);
-        }
-    }
-
-    /**
-     * @returns {boolean} True if the log mode is detached, false otherwise.
-     */
-    private isDetachedMode(): boolean {
-        let isDetached = true;
-        try {
-            isDetached = ServiceLocator.Current.get<CLIService>(CLIService.name).getCurrentArgv().detached;
-        } catch (e) {
-            // Do nothing, this will only occur when service has not been initilized still.
-        }
-        return isDetached;
-    }
-
-    /**
-     * Logs a message to the terminal user interface.
-     * @param msg - The message to log.
-     * @param logBoard - The log board where the message should be printed.
-     */
-    private logToTUI(msg: string, logBoard: LogBoard): void {
-        if (!this.isTerminalUIInitialized()) {
-            this.logger.log(msg);
-            return;
-        }
-
-        switch (logBoard) {
-            case LogBoard.ACCOUNT:
-                this.accountBoard?.log(msg);
-                break;
-            case LogBoard.RELAY:
-                this.relayLog?.log(msg);
-                break;
-            case LogBoard.MIRROR:
-                this.mirrorLog?.log(msg);
-                break;
-            case LogBoard.CONSENSUS:
-                this.consensusLog?.log(msg);
-                break;
-            case LogBoard.RESOURCE:
-                this.resourceBoard?.log(msg);
-                break;
-            default:
-                this.logger?.log(msg);
-                break;
-        }
-    }
-
-    /**
-     * Initializes the terminal user interface.
-     */
-    public initializeTerminalUI(): void {
-        if (this.isDetachedMode() || this.isTerminalUIInitialized()) {
-            return;
-        }
-        
-        const window: Widgets.Screen = screen({
-            smartCSR: true,
-        });
-
-        window.title = 'Hedera Local Node';
-        this.grid = new terminal.grid({ rows: 12, cols: 12, screen: window });
-
-        this.infoBoard = this.initiliazeInfoBoard(this.grid);
-        this.status = this.initiliazeStatusBoard(this.grid);
-        const consensusLog = this.initiliazeConsensusLog(this.grid);
-        const mirrorLog = this.initiliazeMirrorLog(this.grid);
-        const relayLog = this.initiliazeRelayLog(this.grid);
-        const accountBoard = this.initializeAccountBoard(this.grid);
-        const resourceBoard = this.initializeResourceBoard(this.grid);
-
-        // assign key events
-        window.key(
-            ['tab', 'C-c', '1', '2', '3', '4', '5'],
-            async (ch, key) => {
-                if (key.name === 'tab') {
-                    window.focusNext();
-                } else if (ch === '1') {
-                    mirrorLog.hide();
-                    relayLog.hide();
-                    accountBoard.hide();
-                    resourceBoard.hide();
-                    consensusLog.show();
-                    consensusLog.focus();
-                } else if (ch === '2') {
-                    relayLog.hide();
-                    accountBoard.hide();
-                    consensusLog.hide();
-                    resourceBoard.hide();
-                    mirrorLog.show();
-                    mirrorLog.focus();
-                } else if (ch === '3') {
-                    mirrorLog.hide();
-                    accountBoard.hide();
-                    consensusLog.hide();
-                    resourceBoard.hide();
-                    relayLog.show();
-                    relayLog.focus();
-                } else if (ch === '4') {
-                    mirrorLog.hide();
-                    relayLog.hide();
-                    consensusLog.hide();
-                    resourceBoard.hide();
-                    accountBoard.show();
-                    accountBoard.focus();
-                } else if (ch === '5') {
-                    mirrorLog.hide();
-                    relayLog.hide();
-                    consensusLog.hide();
-                    accountBoard.hide();
-                    resourceBoard.show();
-                    resourceBoard.focus();
-                } else {
-                    window.destroy();
-                    process.exit(0);
-                }
-                window.render();
-            }
-        );
-        window.render();
-        this.screen = window;
-        this.consensusLog = consensusLog;
-        this.mirrorLog = mirrorLog;
-        this.relayLog = relayLog;
-        this.accountBoard = accountBoard;
-        this.resourceBoard = resourceBoard;
-    }
-
-    /**
-     * @returns true if the terminal user interface is initialized.
-     */
-    private isTerminalUIInitialized(): boolean {
-        return !!this.screen;
-    }
-
-    /**
-     * Initializes the info board.
-     * @param {terminal.grid} grid - The grid where the info board is placed.
-     * @returns {terminal.Widgets.TableElement} The initialized info board.
-     */
-    private initiliazeInfoBoard(grid: terminal.grid): terminal.Widgets.TableElement {
-        const info = grid.set(0, 7, 2, 3, terminal.table, {
-            keys: true,
-            fg: 'white',
-            label: 'Commands Information',
-            columnSpacing: 1,
-            columnWidth: [10, 30, 30],
-          });
-        info.setData({
-            headers: ['Key', 'Command'],
-            data: [
-              ['1', 'Open Consensus Node Board'],
-              ['2', 'Open Mirror Node Log Board'],
-              ['3', 'Open Relay Log Board'],
-              ['4', 'Open Account Board'],
-              ['5', 'Open Resource Board']
-            ],
-        });
-        return info;
-    }
-
-    /**
-     * Initializes the status board.
-     * @param {terminal.grid} grid - The grid where the status board is placed.
-     * @returns {terminal.Widgets.TableElement} The initialized status board.
-     */
-    private initiliazeStatusBoard(grid: terminal.grid): terminal.Widgets.TableElement {
-        const statusBoard = grid.set(0, 0, 2, 7, terminal.table, {
-            keys: true,
-            fg: 'white',
-            label: 'Status',
-            columnSpacing: 5,
-            columnWidth: [15, 15, 15, 15, 15],
-        });
-        statusBoard.setData({
-            headers: ['Application', 'Version', 'Status', 'Host', 'Port'],
-            data: [],
-        });
-
-        return statusBoard;
-    }
-
-    /**
-     * Updates the status board.
-     * @returns {Promise<void>} A promise that resolves when the status board is updated.
-     * 
-     * @remarks
-     * This method is called by the States.
-     */
-    public async updateStatusBoard(): Promise<void> {
-        const isDetached = ServiceLocator.Current.get<CLIService>(CLIService.name).getCurrentArgv().detached;
-
-        if (isDetached) {
-            return;
-        }
-        const { host } = ServiceLocator.Current.get<CLIService>(CLIService.name).getCurrentArgv();
-        const connectionCheckService = ServiceLocator.Current.get<ConnectionService>(ConnectionService.name);
-        const dockerService = ServiceLocator.Current.get<DockerService>(DockerService.name);
-        const status = this.status as terminal.Widgets.TableElement;
-
-        const data: string[][] = [];
-        await Promise.all(
-            CONTAINERS.map(async (container) => {
-                const row = [];
-                const connectionStatus = await connectionCheckService.checkConnection(container.port)
-                .then(
-                  () => 'Running',
-                  () => 'Not Running'
-                );
-
-                const version = await dockerService.getContainerVersion(container.label);
-                row.push(container.name);
-                row.push(version);
-                row.push(connectionStatus);
-                row.push(host);
-                row.push(container.port.toString());
-                data.push(row);
-            })
-        );
-        status.setData({
-            headers: ['Application', 'Version', 'Status', 'Host', 'Port'],
-            data,
-        });
-        status.render();
-    }
-
-    /**
-     * Initializes the consensus log.
-     * @param {terminal.grid} grid - The grid where the consensus log is placed.
-     * @returns {terminal.Widgets.LogElement} - The initialized consensus log.
-     */
-    private initiliazeConsensusLog(grid: terminal.grid): terminal.Widgets.LogElement {
-        return grid.set(2, 0, 10, 12, log, {
-            fg: 'white',
-            selectedFg: 'white',
-            label: 'Consensus Node Log',
-            scrollable: true,
-            focused: true,
-            keys: true,
-            vi: true,
-            scrollbar: {
-                ch: ' ',
-                inverse: true,
-            },
-        });
-    }
-
-    /**
-     * Initializes the mirror log.
-     * @param {terminal.grid} grid - The grid where the mirror log is placed.
-     * @returns {terminal.Widgets.LogElement} - The initialized mirror log.
-     */
-    private initiliazeMirrorLog(grid: terminal.grid): terminal.Widgets.LogElement {
-        const mirrorLog = grid.set(2, 0, 10, 12, log, {
-            fg: 'white',
-            selectedFg: 'white',
-            label: 'Mirror Node Log',
-            scrollable: true,
-            focused: true,
-            keys: true,
-            vi: true,
-            scrollbar: {
-              ch: ' ',
-              inverse: true,
-            },
-        });
-
-        mirrorLog.hide();
-        return mirrorLog;
-    }
-
-    /**
-     * Initializes the relay log.
-     * @param {terminal.grid} grid - The grid where the relay log is placed.
-     * @returns {terminal.Widgets.LogElement} - The initialized relay log.
-     */
-    private initiliazeRelayLog(grid: terminal.grid): terminal.Widgets.LogElement {
-        const relayLog = grid.set(2, 0, 10, 12, log, {
-            fg: 'white',
-            selectedFg: 'white',
-            label: 'Relay Log',
-            scrollable: true,
-            focused: true,
-            keys: true,
-            vi: true,
-            scrollbar: {
-              ch: ' ',
-              inverse: true,
-            },
-        });
-
-        relayLog.hide();
-        return relayLog;
-    }
-
-    /**
-     * Initializes the account board.
-     * @param {terminal.grid} grid - The grid where the account board is placed.
-     * @returns {terminal.Widgets.LogElement} The initialized account board.
-     */
-    private initializeAccountBoard(grid: terminal.grid): terminal.Widgets.LogElement {
-        const accountBoard = grid.set(2, 0, 10, 12, log, {
-            fg: 'white',
-            selectedFg: 'white',
-            label: 'Account Board',
-            scrollable: true,
-            focused: true,
-            keys: true,
-            vi: true,
-            scrollbar: {
-              ch: ' ',
-              inverse: true,
-            },
-        });
-
-        accountBoard.hide();
-        return accountBoard;
-    }
-
-    /**
-     * Initializes the resource board.
-     * @param {terminal.grid} grid - The grid where the resource board is placed.
-     * @returns {terminal.Widgets.LogElement} The initialized resource board.
-     */
-    private initializeResourceBoard(grid: terminal.grid): terminal.Widgets.LogElement {
-        const resourceBoard = grid.set(2, 0, 10, 12, log, {
-            fg: 'white',
-            selectedFg: 'white',
-            label: 'Resource Board',
-            scrollable: true,
-            focused: true,
-            keys: true,
-            vi: true,
-            scrollbar: {
-                ch: ' ',
-                inverse: true,
-            },
-        });
-
-        resourceBoard.hide();
-        return resourceBoard;
+        this.logger.log(msg);
     }
 }

--- a/src/state/StartState.ts
+++ b/src/state/StartState.ts
@@ -94,7 +94,6 @@ export class StartState implements IState{
      */
     public async onStart(): Promise<void> {
         this.logger.info(START_STATE_STARTING_MESSAGE, this.stateName);
-        this.logger.initializeTerminalUI();
 
         const rootPath = process.cwd();
 
@@ -120,7 +119,6 @@ export class StartState implements IState{
             return;
         }
 
-        await this.logger.updateStatusBoard();
         this.logger.info(START_STATE_STARTED_MESSAGE, this.stateName);
         this.observer?.update(EventType.Finish);
     }

--- a/src/types/CLIOptions.ts
+++ b/src/types/CLIOptions.ts
@@ -26,7 +26,6 @@
  * @property {number} accounts - The number of accounts to be created.
  * @property {boolean} async - Whether to run commands asynchronously.
  * @property {number} balance - The balance for the accounts.
- * @property {boolean} detached - Whether to run in detached mode.
  * @property {string} host - The host address.
  * @property {boolean} limits - Whether to impose limits.
  * @property {boolean} devMode - Whether to run in development mode.
@@ -50,7 +49,6 @@ export interface CLIOptions {
     accounts: number,
     async: boolean,
     balance: number,
-    detached: boolean,
     host: string,
     limits: boolean,
     devMode: boolean,

--- a/test/unit/states/AttachState.spec.ts
+++ b/test/unit/states/AttachState.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon, { SinonSandbox, SinonStub, SinonStubbedInstance } from 'sinon';
+import sinon, { SinonSandbox, SinonStubbedInstance } from 'sinon';
 import { AttachState } from '../../../src/state/AttachState';
 import { IOBserver } from '../../../src/controller/IObserver';
 import { CLIService } from '../../../src/services/CLIService';
@@ -10,25 +10,19 @@ import { getTestBed } from '../testBed';
 
 describe('AttachState', () => {
   let attachState: AttachState,
-      dockerService: SinonStubbedInstance<DockerService>,
       cliService: SinonStubbedInstance<CLIService>,
-      testSandbox: SinonSandbox,
-      loggerService: SinonStubbedInstance<LoggerService>;
+      testSandbox: SinonSandbox;
 
   before(() => {
     const {
         sandbox,
-        dockerServiceStub,
-        cliServiceStub,
-        loggerServiceStub
+        cliServiceStub
     } = getTestBed({
         workDir: 'testDir',
     });
 
-    dockerService = dockerServiceStub
     cliService = cliServiceStub
     testSandbox = sandbox
-    loggerService = loggerServiceStub
 
     // Create an instance of AttachState
     attachState = new AttachState();

--- a/test/unit/states/AttachState.spec.ts
+++ b/test/unit/states/AttachState.spec.ts
@@ -13,8 +13,7 @@ describe('AttachState', () => {
       dockerService: SinonStubbedInstance<DockerService>,
       cliService: SinonStubbedInstance<CLIService>,
       testSandbox: SinonSandbox,
-      loggerService: SinonStubbedInstance<LoggerService>,
-      continuouslyUpdateStatusBoardStub: SinonStub;
+      loggerService: SinonStubbedInstance<LoggerService>;
 
   before(() => {
     const {
@@ -30,8 +29,6 @@ describe('AttachState', () => {
     cliService = cliServiceStub
     testSandbox = sandbox
     loggerService = loggerServiceStub
-
-    continuouslyUpdateStatusBoardStub = testSandbox.stub(AttachState.prototype, <any>'continuouslyUpdateStatusBoard');
 
     // Create an instance of AttachState
     attachState = new AttachState();
@@ -51,27 +48,6 @@ describe('AttachState', () => {
   });
 
   describe('onStart', () => {
-    it('should call attachContainerLogs for consensus, mirror, and relay', async () => {
-      cliService.getCurrentArgv.returns({
-        async: false,
-        blocklisting: false,
-        balance: 1000,
-        accounts: 10,
-        startup: false,
-        detached: false
-      } as any);
-      const attachContainerLogsStub = testSandbox.stub(AttachState.prototype, <any>'attachContainerLogs');
-      await attachState.onStart();
-
-      expect(attachContainerLogsStub.calledThrice).to.be.true;
-      expect(attachContainerLogsStub.firstCall.calledWithExactly("network-node")).to.be.true;
-      expect(attachContainerLogsStub.secondCall.calledWithExactly("mirror-node-rest")).to.be.true;
-      expect(attachContainerLogsStub.thirdCall.calledWithExactly("json-rpc-relay")).to.be.true;
-      testSandbox.assert.called(continuouslyUpdateStatusBoardStub);
-
-      attachContainerLogsStub.restore();
-    });
-
     it('should call observer update attachContainerLogs when detached', async () => {
       (attachState as any).observer = { update: testSandbox.stub()};
       cliService.getCurrentArgv.returns({
@@ -80,75 +56,10 @@ describe('AttachState', () => {
         balance: 1000,
         accounts: 10,
         startup: false,
-        detached: true
       } as any);
-      const attachContainerLogsStub = testSandbox.stub(AttachState.prototype, <any>'attachContainerLogs');
-
       await attachState.onStart();
 
-      testSandbox.assert.called(continuouslyUpdateStatusBoardStub);
       testSandbox.assert.calledOnceWithExactly(attachState.observer?.update, EventType.Finish);
-
-      attachContainerLogsStub.restore();
-    });
-  });
-
-  describe('attachContainerLogs', () => {
-    it('should attach container logs and filter out lines with "Transaction ID: 0.0.2-"', async () => {
-      cliService.getCurrentArgv.returns({
-        async: false,
-        blocklisting: false,
-        balance: 1000,
-        accounts: 10,
-        startup: false,
-        detached: false
-      } as any);
-      const logsSpy = testSandbox.spy();
-      const demuxSpy = testSandbox.spy();
-      dockerService.getContainer.resolves({
-        logs: logsSpy,
-        modem: { demuxStream: demuxSpy },
-      } as any);
-      const attachContainerLogsStub = testSandbox.stub(AttachState.prototype, <any>'attachContainerLogs');
-      attachContainerLogsStub.withArgs("mirror-node-rest").resolves();
-      attachContainerLogsStub.withArgs("json-rpc-relay").resolves();
-      attachContainerLogsStub.callThrough();
-
-      await attachState.onStart();
-
-      testSandbox.assert.calledOnce(dockerService.getContainer);
-      const spy1 = dockerService.getContainer.getCall(0);
-      testSandbox.assert.called(continuouslyUpdateStatusBoardStub);
-      testSandbox.assert.calledWithExactly(spy1, "network-node");
-      testSandbox.assert.calledOnce(logsSpy);
-
-      continuouslyUpdateStatusBoardStub.restore();
-      attachContainerLogsStub.restore();
-    });
-  });
-
-  describe('continuouslyUpdateStatusBoard', () => {
-    it('should updateStatusBoard every 2 seconds', async () => {
-      continuouslyUpdateStatusBoardStub.restore();
-      const continuouslyUpdateStatusBoardSpy = testSandbox.spy(AttachState.prototype, <any>'continuouslyUpdateStatusBoard');
-      cliService.getCurrentArgv.returns({
-        async: false,
-        blocklisting: false,
-        balance: 1000,
-        accounts: 10,
-        startup: false,
-        detached: false
-      } as any);
-      const attachContainerLogsStub = testSandbox.stub(AttachState.prototype, <any>'attachContainerLogs');
-      (attachState as any).timeOut = 2;
-      const iterations = testSandbox.stub(AttachState.prototype, <any>'loopIterations');
-      iterations.returns(2);
-
-      await attachState.onStart();
-
-      testSandbox.assert.called(continuouslyUpdateStatusBoardSpy);
-      testSandbox.assert.calledTwice(loggerService.updateStatusBoard);
-      testSandbox.assert.calledThrice(attachContainerLogsStub);
     });
   });
 });

--- a/test/unit/states/AttachState.spec.ts
+++ b/test/unit/states/AttachState.spec.ts
@@ -3,8 +3,6 @@ import sinon, { SinonSandbox, SinonStubbedInstance } from 'sinon';
 import { AttachState } from '../../../src/state/AttachState';
 import { IOBserver } from '../../../src/controller/IObserver';
 import { CLIService } from '../../../src/services/CLIService';
-import { DockerService } from '../../../src/services/DockerService';
-import { LoggerService } from '../../../src/services/LoggerService';
 import { EventType } from '../../../src/types/EventType';
 import { getTestBed } from '../testBed';
 

--- a/test/unit/states/InitState.spec.ts
+++ b/test/unit/states/InitState.spec.ts
@@ -164,8 +164,6 @@ describe('InitState tests', () => {
         testSandbox.assert.calledOnce(configureEnvVariablesStub);
         testSandbox.assert.calledOnce(configureNodePropertiesStub);
         testSandbox.assert.calledOnce(configureMirrorNodePropertiesStub);
-
-        testSandbox.assert.notCalled(loggerService.initializeTerminalUI);
     })
 
     it('should execute onStart and finish with UnresolvableError on docker checks (Compose Version, Docker Running, Resources)', async () => {
@@ -183,7 +181,6 @@ describe('InitState tests', () => {
         testSandbox.assert.calledWith(observerSpy, EventType.UnresolvableError);
 
         testSandbox.assert.notCalled(dockerService.isPortInUse);
-        testSandbox.assert.notCalled(loggerService.initializeTerminalUI);
     })
 
     describe('private functions', () => {

--- a/test/unit/states/startState.spec.ts
+++ b/test/unit/states/startState.spec.ts
@@ -117,8 +117,6 @@ describe('StartState tests', () => {
 
         testSandbox.assert.calledOnce(processTestBed.processCWDStub);
         testSandbox.assert.calledWith(observerSpy, EventType.Finish);
-
-        testSandbox.assert.calledOnce(loggerService.initializeTerminalUI);
     })
 
     it('should execute onStart and send DockerError event (when dockerComposeUp status code eq 1)', async () => {
@@ -130,8 +128,6 @@ describe('StartState tests', () => {
         testSandbox.assert.match(observerSpy.callCount, 2);
         testSandbox.assert.match(observerSpy.args[0], EventType.DockerError);
         testSandbox.assert.match(observerSpy.args[1], EventType.Finish);
-
-        testSandbox.assert.calledOnce(loggerService.initializeTerminalUI);
     })
 
     it('should execute onStart and handle connectionService error (LocalNodeError)', async () => {
@@ -144,8 +140,6 @@ describe('StartState tests', () => {
         testSandbox.assert.match(observerSpy.callCount, 1);
         testSandbox.assert.match(observerSpy.args[0], EventType.UnknownError);
         testSandbox.assert.calledWith(loggerService.error, 'message', StartState.name);
-
-        testSandbox.assert.calledOnce(loggerService.initializeTerminalUI);
     })
 
     it('should execute onStart and handle connectionService error (generic error)', async () => {
@@ -158,7 +152,5 @@ describe('StartState tests', () => {
         testSandbox.assert.match(observerSpy.callCount, 1);
         testSandbox.assert.match(observerSpy.args[0], EventType.UnknownError);
         testSandbox.assert.notCalled(loggerService.error);
-
-        testSandbox.assert.calledOnce(loggerService.initializeTerminalUI);
     })
 });


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Running the hedera start command show the UI in the command line temporarily and then fails with:
```
─Consensus Node Log─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│[Hedera-Local-Node] INFO (RecoveryState) ⏳ Starting Recovery State...                                                                                                                                                                                                      │
│[Hedera-Local-Node] INFO (RecoveryState) ⏳ Trying to startup again...                                                                                                                                                                                                       │[Hedera-Local-Node] INFO (StartState) ⏳ Detecting network...
│[Hedera-Local-Node] INFO (ConnectionService) Mirror Node GRPC not yet available at: 127.0.0.1:5600. Retrying...                                                                                                                                                             │
│[Hedera-Local-Node] INFO (ConnectionService) Mirror Node GRPC not yet available at: 127.0.0.1:5600. Retrying...                                                                                                                                                             │
│[Hedera-Local-Node] INFO (ConnectionService) Mirror Node GRPC not yet available at: 127.0.0.1:5600. Retrying...
...
[Hedera-Local-Node] INFO (InitState) [✔︎] Needed bootsrap properties were set for this configuration.
[Hedera-Local-Node] INFO (InitState) [✔︎] Needed mirror node properties were set for this configuration.
[Hedera-Local-Node] INFO (StartState) ⏳ Starting Hedera Local Node...
──────────────────────────────────────────────────────────────────────────────

Error on xterm-256color.Setulc:
"\u001b[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m"

var v,
 stack = [],
 out = ["\x1b[58::2::"];
(stack.push(v = params[0]),
 v),
(stack.push(v = 65536),
 v),
(v = stack.pop(),
 stack.push(v = (stack.pop() / v) || 0),
 v),
out.push(stack.pop()),
out.push("::"),
(stack.push(v = params[0]),
 v),
(stack.push(v = 256),
 v),
(v = stack.pop(),
 stack.push(v = (stack.pop() / v) || 0),
 v),
(stack.push(v = 255),
 v),
(v = stack.pop(),
 stack.push(v = (stack.pop() & v) || 0),
 v),
out.push(stack.pop()),
out.push("::"),
(stack.push(v = params[0]),
 v),
(stack.push(v = 255),
 v),
(v = stack.pop(),
 stack.push(v = (stack.pop() & v) || 0),
 v),
out.push(stack.pop())}out.push("m");
return out.join("");
```

The PR completely deprecates the Sunset TUI because it does not reach the desired user experience. Also, it depends on the local user's terminal and might cause unnecessary debugging overhead.

Removing tui makes the `detached` flag useless, so it's removed as well in this PR.

**Related issue(s)**:

Fixes #820 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
