### PR TITLE
feat:  add a start-up check for minimum node and npm versions

### DIFF
--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -149,8 +149,8 @@ export class InitState implements IState{
     }
 
     private checkNodeAndNpmVersions(): boolean {
-        const MIN_NODE_VERSION = "17.9.1";
-        const MIN_NPM_VERSION = "8.11.0";
+        const MIN_NODE_VERSION = '17.9.1';
+        const MIN_NPM_VERSION = '8.11.0';
         const V_OR_NEW_LINE_REGEX = /v|\n/g;
 
         const nodeVersion = shell.exec(`node -v `, { silent: true }).replace(V_OR_NEW_LINE_REGEX, '');

--- a/src/state/InitState.ts
+++ b/src/state/InitState.ts
@@ -18,6 +18,8 @@
  *
  */
 
+import semver from'semver';
+import shell from 'shelljs';
 import { configDotenv } from 'dotenv';
 import { readFileSync, writeFileSync } from 'fs';
 import path, { join } from 'path';
@@ -119,8 +121,9 @@ export class InitState implements IState{
         const isCorrectDockerComposeVersion = await this.dockerService.isCorrectDockerComposeVersion();
         const isDockerStarted = await this.dockerService.checkDocker();
         const dockerHasEnoughResources = await this.dockerService.checkDockerResources(this.cliOptions.multiNode);
+        const areNodeAndNpmVersionsValid = this.checkNodeAndNpmVersions();
 
-        if (!(isCorrectDockerComposeVersion && isDockerStarted && dockerHasEnoughResources)) {
+        if (!(isCorrectDockerComposeVersion && isDockerStarted && dockerHasEnoughResources) && areNodeAndNpmVersionsValid) {
             this.observer!.update(EventType.UnresolvableError);
             return;
         }
@@ -143,6 +146,27 @@ export class InitState implements IState{
         this.configureMirrorNodeProperties();
 
         this.observer!.update(EventType.Finish);
+    }
+
+    private checkNodeAndNpmVersions(): boolean {
+        const MIN_NODE_VERSION = "17.9.1";
+        const MIN_NPM_VERSION = "8.11.0";
+        const V_OR_NEW_LINE_REGEX = /v|\n/g;
+
+        const nodeVersion = shell.exec(`node -v `, { silent: true }).replace(V_OR_NEW_LINE_REGEX, '');
+        const npmVersion = shell.exec(`npm -v `, { silent: true }).replace(V_OR_NEW_LINE_REGEX, '');
+
+        const isNodeVersionValid = semver.gte(nodeVersion, MIN_NODE_VERSION);
+        const isNpmVersionValid = semver.gte(npmVersion, MIN_NPM_VERSION);
+
+        if (!isNodeVersionValid) {
+            this.logger.error(`Current node version is ${nodeVersion} but minimum required one is ${MIN_NODE_VERSION}`);
+        }
+        if (!isNpmVersionValid) {
+            this.logger.error(`Current npm version is ${npmVersion} but minimum required one is ${MIN_NPM_VERSION}`);
+        }
+
+        return isNodeVersionValid && isNpmVersionValid;
     }
 
     /**

--- a/test/unit/states/InitState.spec.ts
+++ b/test/unit/states/InitState.spec.ts
@@ -147,6 +147,7 @@ describe('InitState tests', () => {
         dockerService.isCorrectDockerComposeVersion.resolves(true)
         dockerService.checkDocker.resolves(true)
         dockerService.checkDockerResources.resolves(true)
+        testSandbox.stub(initState, 'checkNodeAndNpmVersions').returns(true);
 
         await initState.onStart();
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->


Currently, the user is not warned if their node/npm version is outdated and doesn't meet the minimum requirements.

**Solution**:

Add a start-up check for the node/npm version.

**Related issue(s)**:

Fixes #863 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
