### PR TITLE
chore: Update which secret is used for publishing local node.

### DIFF
--- a/.github/workflows/publish-npm-package.yaml
+++ b/.github/workflows/publish-npm-package.yaml
@@ -36,4 +36,4 @@ jobs:
       - name: Publish npm package
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_HG_TOKEN }}


### PR DESCRIPTION
## Description

This pull request updates the npm publish workflow to use a different authentication token for publishing packages. The change ensures that the workflow uses the correct secret for authentication.

* Workflow authentication update:
  * [`.github/workflows/publish-npm-package.yaml`](diffhunk://#diff-4629cb279ac6aded766c23d4ffe483056ed725131ee166f963db4171e5115c00L39-R39): Changed the environment variable from `NPM_TOKEN` to `NPM_HG_TOKEN` for the `NODE_AUTH_TOKEN` used in the npm publish step.

## Related Issue(s)

Closes #1225 