### PR TITLE
chore: update version to 2.39.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.39.2",
+  "version": "2.39.3",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
Update the version to `v2.39.3`.

Related to #1258 