### PR TITLE
chore: bump CN and MN to stable versions

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ NETWORK_NODE_IMAGE_PREFIX=gcr.io/hedera-registry/
 NETWORK_NODE_IMAGE_NAME=consensus-node
 
 #### Image Tags/Hashes ####
-NETWORK_NODE_IMAGE_TAG=0.72.0-rc.1
-HAVEGED_IMAGE_TAG=0.72.0-rc.1
+NETWORK_NODE_IMAGE_TAG=0.72.0
+HAVEGED_IMAGE_TAG=0.72.0
 
 #### Java Process Settings ####
 PLATFORM_JAVA_HEAP_MIN=256m
@@ -28,7 +28,7 @@ PYTHON_VERSION=python3.7
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.150.0-rc1
+MIRROR_IMAGE_TAG=0.150.0
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=ghcr.io/mhga24/postgres:latest

--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ PYTHON_VERSION=python3.7
 
 #### MirrorNode Prefixes & Tags ####
 MIRROR_IMAGE_PREFIX=gcr.io/mirrornode/
-MIRROR_IMAGE_TAG=0.150.0
+MIRROR_IMAGE_TAG=0.151.0
 
 #### MirrorNode settings ####
 MIRROR_POSTGRES_IMAGE=ghcr.io/mhga24/postgres:latest

--- a/config.yaml
+++ b/config.yaml
@@ -341,7 +341,7 @@ services:
       HEDERA_MIRROR_GRPC_DB_HOST: db
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-grpc/
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.150.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.150.0
     mem_limit: "536870912"
     memswap_limit: "536870912"
     networks:
@@ -362,7 +362,7 @@ services:
     command:
       - -d 16
     container_name: haveged
-    image: gcr.io/hedera-registry/network-node-haveged:0.72.0-rc.1
+    image: gcr.io/hedera-registry/network-node-haveged:0.72.0
     network_mode: none
     privileged: true
     restart: always
@@ -379,7 +379,7 @@ services:
       HEDERA_MIRROR_IMPORTER_DB_HOST: db
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-importer/
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.150.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.150.0
     mem_limit: "805306368"
     memswap_limit: "805306368"
     networks:
@@ -450,7 +450,7 @@ services:
     environment:
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-monitor/
-    image: gcr.io/mirrornode/hedera-mirror-monitor:0.150.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-monitor:0.150.0
     mem_limit: "536870912"
     memswap_limit: "536870912"
     networks:
@@ -495,7 +495,7 @@ services:
       interval: 30s
       retries: 10
       start_period: 10s
-    image: gcr.io/hedera-registry/consensus-node:0.72.0-rc.1
+    image: gcr.io/hedera-registry/consensus-node:0.72.0
     mem_limit: "4294967296"
     memswap_limit: "4294967296"
     networks:
@@ -609,7 +609,7 @@ services:
       interval: 30s
       retries: 10
       start_period: 10s
-    image: gcr.io/hedera-registry/consensus-node:0.72.0-rc.1
+    image: gcr.io/hedera-registry/consensus-node:0.72.0
     mem_limit: "4294967296"
     memswap_limit: "4294967296"
     networks:
@@ -714,7 +714,7 @@ services:
       interval: 30s
       retries: 10
       start_period: 10s
-    image: gcr.io/hedera-registry/consensus-node:0.72.0-rc.1
+    image: gcr.io/hedera-registry/consensus-node:0.72.0
     mem_limit: "4294967296"
     memswap_limit: "4294967296"
     networks:
@@ -819,7 +819,7 @@ services:
       interval: 30s
       retries: 10
       start_period: 10s
-    image: gcr.io/hedera-registry/consensus-node:0.72.0-rc.1
+    image: gcr.io/hedera-registry/consensus-node:0.72.0
     mem_limit: "4294967296"
     memswap_limit: "4294967296"
     networks:
@@ -1383,7 +1383,7 @@ services:
         required: true
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.150.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.150.0
     mem_limit: "536870912"
     memswap_limit: "536870912"
     networks:
@@ -1407,7 +1407,7 @@ services:
       HEDERA_MIRROR_RESTJAVA_DB_HOST: db
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-rest-java/
-    image: gcr.io/mirrornode/hedera-mirror-rest-java:0.150.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-rest-java:0.150.0
     mem_limit: "536870912"
     memswap_limit: "536870912"
     networks:
@@ -1439,7 +1439,7 @@ services:
       HEDERA_MIRROR_WEB3_EVM_NETWORK: OTHER
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-web3/
-    image: gcr.io/mirrornode/hedera-mirror-web3:0.150.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-web3:0.150.0
     mem_limit: "1073741824"
     memswap_limit: "1073741824"
     networks:

--- a/config.yaml
+++ b/config.yaml
@@ -341,7 +341,7 @@ services:
       HEDERA_MIRROR_GRPC_DB_HOST: db
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-grpc/
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.150.0
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.151.0
     mem_limit: "536870912"
     memswap_limit: "536870912"
     networks:
@@ -379,7 +379,7 @@ services:
       HEDERA_MIRROR_IMPORTER_DB_HOST: db
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-importer/
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.150.0
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.151.0
     mem_limit: "805306368"
     memswap_limit: "805306368"
     networks:
@@ -450,7 +450,7 @@ services:
     environment:
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-monitor/
-    image: gcr.io/mirrornode/hedera-mirror-monitor:0.150.0
+    image: gcr.io/mirrornode/hedera-mirror-monitor:0.151.0
     mem_limit: "536870912"
     memswap_limit: "536870912"
     networks:
@@ -1383,7 +1383,7 @@ services:
         required: true
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.150.0
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.151.0
     mem_limit: "536870912"
     memswap_limit: "536870912"
     networks:
@@ -1407,7 +1407,7 @@ services:
       HEDERA_MIRROR_RESTJAVA_DB_HOST: db
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-rest-java/
-    image: gcr.io/mirrornode/hedera-mirror-rest-java:0.150.0
+    image: gcr.io/mirrornode/hedera-mirror-rest-java:0.151.0
     mem_limit: "536870912"
     memswap_limit: "536870912"
     networks:
@@ -1439,7 +1439,7 @@ services:
       HEDERA_MIRROR_WEB3_EVM_NETWORK: OTHER
       JAVA_TOOL_OPTIONS: ""
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-web3/
-    image: gcr.io/mirrornode/hedera-mirror-web3:0.150.0
+    image: gcr.io/mirrornode/hedera-mirror-web3:0.151.0
     mem_limit: "1073741824"
     memswap_limit: "1073741824"
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.40.0",
+  "version": "2.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-local",
-      "version": "2.40.0",
+      "version": "2.40.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/sdk": "2.66.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-local",
-  "version": "2.40.0",
+  "version": "2.40.1",
   "description": "Developer tooling for running Local Hedera Network (Consensus + Mirror Nodes).",
   "main": "index.ts",
   "scripts": {

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -1,9 +1,9 @@
 {
   "imageTagConfiguration": [
-    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.72.0-rc.1"},
-    {"key": "HAVEGED_IMAGE_TAG", "value": "0.72.0-rc.1"},
+    {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.72.0"},
+    {"key": "HAVEGED_IMAGE_TAG", "value": "0.72.0"},
     {"key": "BLOCK_NODE_IMAGE_TAG", "value": "0.27.0"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.150.0-rc1"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.150.0"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.75.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],

--- a/src/configuration/local.json
+++ b/src/configuration/local.json
@@ -3,7 +3,7 @@
     {"key": "NETWORK_NODE_IMAGE_TAG", "value": "0.72.0"},
     {"key": "HAVEGED_IMAGE_TAG", "value": "0.72.0"},
     {"key": "BLOCK_NODE_IMAGE_TAG", "value": "0.27.0"},
-    {"key": "MIRROR_IMAGE_TAG", "value": "0.150.0"},
+    {"key": "MIRROR_IMAGE_TAG", "value": "0.151.0"},
     {"key": "RELAY_IMAGE_TAG", "value": "0.75.0"},
     {"key": "MIRROR_NODE_EXPLORER_IMAGE_TAG", "value": "24.4.0"}
   ],


### PR DESCRIPTION
**Description**:

This PR bumps Consensus node to `0.72.0` and Mirror Node to `0.151.0`. It also bumps the package version in preparation for a new release.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
